### PR TITLE
Update BCFTOOLS_NORM config

### DIFF
--- a/conf/modules/snv_annotation.config
+++ b/conf/modules/snv_annotation.config
@@ -28,6 +28,10 @@ process {
         ext.prefix = { "${meta.id}_ac" }
     }
 
+    withName: '.*:SNV_ANNOTATION:BCFTOOLS_NORM' {
+        ext.args = "-m - --output-type b -w 10000"
+    }
+
     withName: '.*:SNV_ANNOTATION:BCFTOOLS_NORM_SINGLESAMPLE' {
         ext.args = "-m - --output-type b -w 10000"
     }


### PR DESCRIPTION
Full size test fails because only `BCFTOOLS_NORM_SINGLESAMPLE` and not `BCFTOOLS_NORM` was actually decomposing variants. 

This is not caught in the small test profile, I guess because it does not contain variants that need decomposing.

<!--
# genomic-medicine-sweden/nallo pull request

Many thanks for contributing to genomic-medicine-sweden/nallo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
