### PR TITLE
Update whatshap stats version to avoid ZeroDivisionError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.1.0 - [2024-05-03]
+## v0.1.0 - [2024-05-06]
 
 Initial release of genomic-medicine-sweden/nallo, created with the [nf-core](https://nf-co.re/) template.
 

--- a/modules/local/whatshap/stats/main.nf
+++ b/modules/local/whatshap/stats/main.nf
@@ -2,8 +2,8 @@ process WHATSHAP_STATS {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::whatshap=1.7 bioconda::tabix=1.11"
-    container "docker.io/fellen31/whatshap-tabix:latest"
+    conda "bioconda::whatshap=2.2 bioconda::tabix=1.11"
+    container "docker.io/fellen31/whatshap-tabix:2.2"
 
     input:
     tuple val(meta), path(vcf), path(tbi)


### PR DESCRIPTION
Already updated whatshap phase & whatshap haplotag but forgot whatshap stats.
A mulled container will be added in a later release. 

<!--
# genomic-medicine-sweden/nallo pull request

Many thanks for contributing to genomic-medicine-sweden/nallo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
