### PR TITLE
Merge fastq files before raw read qc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#185](https://github.com/genomic-medicine-sweden/nallo/pull/185) - Removed samtools index from repeat calling workflow, as bai is now used in pipeline
 - [#185](https://github.com/genomic-medicine-sweden/nallo/pull/185) - Removed versions.yml output from minimap2 align
 - [#185](https://github.com/genomic-medicine-sweden/nallo/pull/185) - Removed echtvar anno output
+- [#212](https://github.com/genomic-medicine-sweden/nallo/pull/212) - Files that are from the same sample are now merged before FastQC
 
 ### `Fixed`
 

--- a/workflows/nallo.nf
+++ b/workflows/nallo.nf
@@ -35,6 +35,7 @@ include { SPLIT_BED_CHUNKS       } from '../modules/local/split_bed_chunks/main'
 include { SAMTOOLS_MERGE         } from '../modules/nf-core/samtools/merge/main'
 
 // nf-core
+include { CAT_FASTQ              } from '../modules/nf-core/cat/fastq/'
 include { FASTQC                 } from '../modules/nf-core/fastqc/main'
 include { FASTP                  } from '../modules/nf-core/fastp/main'
 include { MINIMAP2_ALIGN         } from '../modules/nf-core/minimap2/align/main'
@@ -107,15 +108,30 @@ workflow NALLO {
     BAM_TO_FASTQ.out.fastq
         .set { ch_sample }
 
-    // Now this will be done per file and not per sample, not ideal
     if(!params.skip_raw_read_qc) {
 
-        // Fastq QC
-        FASTQC( ch_sample )
+        // Cat samples with multiple input files before QC - still not ideal
+        ch_sample
+            .groupTuple()
+            .branch { meta, reads ->
+                single: reads.size() == 1
+                    return [ meta, reads[0] ]
+                multiple: reads.size() > 1
+            }
+            .set { ch_sample_reads }
+
+        CAT_FASTQ ( ch_sample_reads.multiple )
+        ch_versions = ch_versions.mix(CAT_FASTQ.out.versions)
+
+        ch_sample_reads.single
+            .concat ( CAT_FASTQ.out.reads )
+            .set { raw_read_qc_in }
+
+        FASTQC( raw_read_qc_in )
         ch_versions = ch_versions.mix(FASTQC.out.versions)
         ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}ifEmpty([]))
 
-        FQCRS( ch_sample )
+        FQCRS( raw_read_qc_in )
         ch_versions = ch_versions.mix(FQCRS.out.versions)
     }
 

--- a/workflows/nallo.nf
+++ b/workflows/nallo.nf
@@ -129,7 +129,7 @@ workflow NALLO {
 
         FASTQC( raw_read_qc_in )
         ch_versions = ch_versions.mix(FASTQC.out.versions)
-        ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}ifEmpty([]))
+        ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
 
         FQCRS( raw_read_qc_in )
         ch_versions = ch_versions.mix(FQCRS.out.versions)


### PR DESCRIPTION
This is not an ideal solution (performance and disk usage wise), but needs to be fixed before a release. Otherwise, only one of the file is included in the MultiQC report. 

Closes #211 
<!--
# genomic-medicine-sweden/nallo pull request

Many thanks for contributing to genomic-medicine-sweden/nallo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
