### PR TITLE
Fix linting warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#231](https://github.com/genomic-medicine-sweden/nallo/pull/231) - Fixed certain tags in input BAM files being transfered over to (re)aligned BAM
 - [#252](https://github.com/genomic-medicine-sweden/nallo/pull/252) - Fixed duplicate SNVs in outputs when providing a BED-regions with overlapping regions
+- [#267](https://github.com/genomic-medicine-sweden/nallo/pull/267) - Fixed warning where `MODKIT_PILEUP_HAPLOTYPES` would be defined more than once
 
 ### Parameters
 

--- a/conf/modules/methylation.config
+++ b/conf/modules/methylation.config
@@ -24,7 +24,7 @@ process {
         ]
     }
 
-    withName: '.*:METHYLATION:MODKIT_PILEUP' {
+    withName: '.*:METHYLATION:MODKIT_PILEUP_UNPHASED' {
 
         ext.args = '--combine-mods --cpg --combine-strands'
         ext.prefix = { "${meta.id}_modkit_pileup" }
@@ -36,7 +36,7 @@ process {
         ]
     }
 
-    withName: '.*:METHYLATION:MODKIT_PILEUP_HAPLOTYPES' {
+    withName: '.*:METHYLATION:MODKIT_PILEUP_PHASED' {
 
         ext.args = '--combine-mods --cpg --combine-strands --partition-tag HP'
         ext.prefix = { "${meta.id}_modkit_pileup_phased" }
@@ -49,7 +49,7 @@ process {
 
     }
 
-    withName: '.*:METHYLATION:BGZIP_MODKIT_PILEUP' {
+    withName: '.*:METHYLATION:BGZIP_MODKIT_PILEUP_UNPHASED' {
 
         ext.prefix = { "${input.simpleName}" }
 
@@ -60,7 +60,7 @@ process {
         ]
     }
 
-    withName: '.*:METHYLATION:BGZIP_MODKIT_PILEUP_HAPLOTYPES' {
+    withName: '.*:METHYLATION:BGZIP_MODKIT_PILEUP_PHASED' {
 
         ext.prefix = { "${input.simpleName}" }
 

--- a/subworkflows/local/methylation.nf
+++ b/subworkflows/local/methylation.nf
@@ -1,7 +1,7 @@
-include { MODKIT_PILEUP                                      } from '../../modules/nf-core/modkit/pileup/main'
-include { MODKIT_PILEUP as MODKIT_PILEUP_HAPLOTYPES          } from '../../modules/nf-core/modkit/pileup/main'
-include { TABIX_BGZIPTABIX as BGZIP_MODKIT_PILEUP            } from '../../modules/nf-core/tabix/bgziptabix/main'
-include { TABIX_BGZIPTABIX as BGZIP_MODKIT_PILEUP_HAPLOTYPES } from '../../modules/nf-core/tabix/bgziptabix/main'
+include { MODKIT_PILEUP as MODKIT_PILEUP_UNPHASED          } from '../../modules/nf-core/modkit/pileup/main'
+include { MODKIT_PILEUP as MODKIT_PILEUP_PHASED            } from '../../modules/nf-core/modkit/pileup/main'
+include { TABIX_BGZIPTABIX as BGZIP_MODKIT_PILEUP_UNPHASED } from '../../modules/nf-core/tabix/bgziptabix/main'
+include { TABIX_BGZIPTABIX as BGZIP_MODKIT_PILEUP_PHASED   } from '../../modules/nf-core/tabix/bgziptabix/main'
 
 workflow METHYLATION {
 
@@ -15,22 +15,22 @@ workflow METHYLATION {
     ch_versions = Channel.empty()
 
     // Run modkit pileup once without dividing by HP-tag and once with
-    MODKIT_PILEUP(ch_haplotagged_bam_bai, ch_fasta, ch_bed)
-    ch_versions = ch_versions.mix(MODKIT_PILEUP.out.versions)
+    MODKIT_PILEUP_UNPHASED (ch_haplotagged_bam_bai, ch_fasta, ch_bed)
+    ch_versions = ch_versions.mix(MODKIT_PILEUP_UNPHASED.out.versions)
 
-    MODKIT_PILEUP_HAPLOTYPES(ch_haplotagged_bam_bai, ch_fasta, ch_bed)
-    ch_versions = ch_versions.mix(MODKIT_PILEUP_HAPLOTYPES.out.versions)
+    MODKIT_PILEUP_PHASED (ch_haplotagged_bam_bai, ch_fasta, ch_bed)
+    ch_versions = ch_versions.mix(MODKIT_PILEUP_PHASED.out.versions)
 
     // Bgzip and index output "BED"
-    BGZIP_MODKIT_PILEUP ( MODKIT_PILEUP.out.bed )
-    ch_versions = ch_versions.mix(BGZIP_MODKIT_PILEUP.out.versions)
+    BGZIP_MODKIT_PILEUP_UNPHASED ( MODKIT_PILEUP_UNPHASED.out.bed )
+    ch_versions = ch_versions.mix(BGZIP_MODKIT_PILEUP_UNPHASED.out.versions)
 
-    MODKIT_PILEUP_HAPLOTYPES.out.bed
+    MODKIT_PILEUP_PHASED.out.bed
         .transpose()
-        .set { ch_bgzip_modkit_haplotypes_in }
+        .set { ch_bgzip_modkit_pileup_phased_in }
 
-    BGZIP_MODKIT_PILEUP_HAPLOTYPES ( ch_bgzip_modkit_haplotypes_in )
-    ch_versions = ch_versions.mix(BGZIP_MODKIT_PILEUP_HAPLOTYPES.out.versions)
+    BGZIP_MODKIT_PILEUP_PHASED ( ch_bgzip_modkit_pileup_phased_in )
+    ch_versions = ch_versions.mix(BGZIP_MODKIT_PILEUP_PHASED.out.versions)
 
     emit:
     versions = ch_versions // channel: [ versions.yml ]


### PR DESCRIPTION
Fixes

```
WARN: A process with name 'MODKIT_PILEUP_HAPLOTYPES' is defined more than once in module script: /home/runner/work/nallo/nallo/./workflows/../subworkflows/local/methylation.nf -- Make sure to not define the same function as process
```
<!--
# genomic-medicine-sweden/nallo pull request

Many thanks for contributing to genomic-medicine-sweden/nallo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
