### PR TITLE
Rank variants in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#268](https://github.com/genomic-medicine-sweden/nallo/pull/268) - Only output unphased alignments when phasing is off
 - [#268](https://github.com/genomic-medicine-sweden/nallo/pull/268) - Changed alignment output file names and directory structure
 - [#277](https://github.com/genomic-medicine-sweden/nallo/pull/277) - Allowed CNV calling as soon as SNV calling for a sample is finished
+- [#278](https://github.com/genomic-medicine-sweden/nallo/pull/278) - Changed the SNV ranking to run in parallel per region
 
 ### `Removed`
 

--- a/conf/modules/general.config
+++ b/conf/modules/general.config
@@ -34,7 +34,7 @@ process {
     }
 
     withName: '.*:NALLO:BCFTOOLS_CONCAT' {
-        ext.prefix = { params.skip_snv_annotation ? "${meta.id}_snv" : "${meta.id}_snv_annotated" }
+        ext.prefix = { params.skip_snv_annotation ? "${meta.id}_snv" : (params.skip_rank_variants ? "${meta.id}_snv_annotated" : "${meta.id}_snv_annotated_ranked") }
         ext.args = { [
             '--allow-overlaps',
             '--output-type z',
@@ -43,7 +43,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/snvs/multi_sample/${meta.id}" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : (!params.skip_rank_variants && !params.skip_snv_annotation ? null : filename) }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 

--- a/conf/modules/rank_variants.config
+++ b/conf/modules/rank_variants.config
@@ -17,6 +17,12 @@
 
 process {
 
+    withName: '.*:RANK_VARIANTS_SNV:.*' {
+        publishDir = [
+            enabled: false,
+        ]
+    }
+
     withName: '.*:RANK_VARIANTS_SNV:GENMOD_ANNOTATE' {
         ext.prefix = { "${meta.id}_snv_genmod_annotate" }
         ext.args = { [
@@ -45,20 +51,4 @@ process {
         ext.when = false
     }
 
-    withName: '.*:RANK_VARIANTS_SNV:TABIX_BGZIP' {
-        ext.prefix = { "${meta.id}_snv_annotated_ranked" }
-        publishDir = [
-            path: { "${params.outdir}/snvs/multi_sample/${meta.id}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-    }
-
-    withName: '.*:RANK_VARIANTS_SNV:TABIX_TABIX' {
-        publishDir = [
-            path: { "${params.outdir}/snvs/multi_sample/${meta.id}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-    }
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -51,7 +51,7 @@ params {
     // Somalier
     somalier_sites = params.pipelines_testdata_base_path + 'nallo/reference/somalier_sites.vcf.gz'
 
-    parallel_snv = 3 // Create 3 parallel DeepVariant processes
+    parallel_snv = 2 // Create 2 parallel DeepVariant processes
     preset = "revio"
 
 }

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -30,7 +30,7 @@ nextflow_pipeline {
                 variant_consequences_snv = params.pipelines_testdata_base_path + 'nallo/reference/variant_consequences_v2.txt'
 
                 // Parameters
-                parallel_snv    = 3
+                parallel_snv    = 2
                 preset          = "revio"
                 outdir          = "$outputDir"
             }
@@ -162,7 +162,7 @@ nextflow_pipeline {
                 variant_consequences_snv = params.pipelines_testdata_base_path + 'nallo/reference/variant_consequences_v2.txt'
 
                 // Parameters
-                parallel_snv    = 3
+                parallel_snv    = 2
                 preset          = "revio"
                 outdir          = "$outputDir"
             }


### PR DESCRIPTION
Ranking a VEP annotated VCF with 12 samples and 13M variants used >200GB RAM. This PR reduced that to 20-25 GB.

Since the pipeline doesn't split chromosomes into multiple regions, genmod should be ok to run per chromosome/contig. 

Genmod doesn't allow empty VCF files though. In the testdata region 2.bed contains only RefCall variants, so `--parallel_snv` needs to be reduced to 2, or testdata updated.

Closes #275 

<!--
# genomic-medicine-sweden/nallo pull request

Many thanks for contributing to genomic-medicine-sweden/nallo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
