### PR TITLE
Remove sex check bottleneck 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#278](https://github.com/genomic-medicine-sweden/nallo/pull/278) - Changed the SNV ranking to run in parallel per region
 - [#300](https://github.com/genomic-medicine-sweden/nallo/pull/300) - Clarified and formatted nallo.nf
 - [#306](https://github.com/genomic-medicine-sweden/nallo/pull/306) - Updated echtvar version
+- [#307](https://github.com/genomic-medicine-sweden/nallo/pull/307) - Changed somalier relate to also run per sample on sampes with unknown sex, removing the need to wait on all samples to finish aligment before starting variant calling
+- [#307](https://github.com/genomic-medicine-sweden/nallo/pull/307) - Changed the removal of n_files from meta from bam_infer_sex to nallo.nf
 
 ### `Removed`
 

--- a/conf/modules/bam_infer_sex.config
+++ b/conf/modules/bam_infer_sex.config
@@ -24,7 +24,11 @@ process {
         ]
     }
 
-    withName: '.*:BAM_INFER_SEX:SOMALIER_RELATE' {
+    withName: '.*:BAM_INFER_SEX:RELATE_INFER' {
+        ext.args = '--infer'
+    }
+
+    withName: '.*:BAM_INFER_SEX:RELATE_RELATE' {
         ext.args = '--infer'
         publishDir = [
             path: { "${params.outdir}/qc_aligned_reads/somalier/relate/${meta.id}" },

--- a/subworkflows/local/bam_infer_sex.nf
+++ b/subworkflows/local/bam_infer_sex.nf
@@ -1,5 +1,6 @@
-include { SOMALIER_EXTRACT } from '../../modules/nf-core/somalier/extract/main'
-include { SOMALIER_RELATE  } from '../../modules/nf-core/somalier/relate/main'
+include { SOMALIER_EXTRACT                 } from '../../modules/nf-core/somalier/extract/main'
+include { SOMALIER_RELATE as RELATE_INFER  } from '../../modules/nf-core/somalier/relate/main'
+include { SOMALIER_RELATE as RELATE_RELATE } from '../../modules/nf-core/somalier/relate/main'
 
 workflow BAM_INFER_SEX {
 
@@ -23,16 +24,15 @@ workflow BAM_INFER_SEX {
     ch_versions = ch_versions.mix(SOMALIER_EXTRACT.out.versions)
 
     SOMALIER_EXTRACT.out.extract
-        .map { meta, extract -> [ [ id: meta.project ], extract ] }
-        .groupTuple()
-        .join( ch_ped )
-        .set { ch_somalier_relate_in }
+        .combine( ch_ped.map { meta, ped -> ped } )
+        .filter { meta, extract, ped -> meta.sex == 0 }
+        .set { ch_relate_infer_in }
 
-    // Infer sex
-    SOMALIER_RELATE ( ch_somalier_relate_in, [] )
-    ch_versions = ch_versions.mix(SOMALIER_RELATE.out.versions)
+    // 1. Run somalier relate on one sample at a time to infer sex
+    RELATE_INFER ( ch_relate_infer_in, [] )
+    ch_versions = ch_versions.mix(RELATE_INFER.out.versions)
 
-    SOMALIER_RELATE.out.samples_tsv
+    RELATE_INFER.out.samples_tsv
         .map { meta, tsv -> tsv }
         .splitCsv(header: true, sep: '\t')
         .set { somalier_tsv }
@@ -46,31 +46,43 @@ workflow BAM_INFER_SEX {
         }
         .set { ch_somalier_sex }
 
-    // Use sex from somalier for samples with unknown sex (sex == 0) in samplesheet
+    // Branch on samples with known/unknown sex
     ch_bam_bai
+        .branch { meta, bam, bai ->
+            unknown_sex: meta.sex == 0
+            known_sex: meta.sex != 0
+        }
+        .set { ch_samples }
+
+    // Update sex with sex from somalier for samples with unknown sex
+    ch_samples.unknown_sex
         .map { meta, bam, bai -> [ meta.id, meta, bam, bai ] }
         .join( ch_somalier_sex )
         .map { id, meta, bam, bai, somalier ->
-            new_meta = [
-                id          : meta.id,
-                family_id   : meta.family_id,
-                paternal_id : meta.paternal_id,
-                maternal_id : meta.maternal_id,
-                sex         : meta.sex == 0 ? somalier.sex.toInteger() : meta.sex,
-                phenotype   : meta.phenotype,
-                single_end  : meta.single_end,
-                project     : meta.project
-            ]
-            [ new_meta, bam, bai ]
+            updated_sex = (meta.sex == 0 ? somalier.sex.toInteger() : meta.sex)
+            [ meta + [sex: updated_sex], bam, bai ]
         }
         .set { ch_updated_sex }
+
+    // Add samples with known sex
+    ch_updated_sex = ch_updated_sex.mix(ch_samples.known_sex)
+
+    // 2. Run relate on all samples at once to check relatedness
+    SOMALIER_EXTRACT.out.extract
+        .map { meta, extract -> [ [ id: meta.project ], extract ] }
+        .groupTuple()
+        .join( ch_ped )
+        .set { ch_relate_relate_in }
+
+    RELATE_RELATE ( ch_relate_relate_in, [] )
+    ch_versions = ch_versions.mix(RELATE_RELATE.out.versions)
 
     emit:
     bam              = ch_updated_sex.map { meta, bam, bai -> [ meta, bam ] } // channel: [ val(meta), path(bam) ]
     bai              = ch_updated_sex.map { meta, bam, bai -> [ meta, bai ] } // channel: [ val(meta), path(bai) ]
     bam_bai          = ch_updated_sex                                         // channel: [ val(meta), path(bam), path(bai) ]
-    somalier_samples = SOMALIER_RELATE.out.samples_tsv                        // channel: [ val(meta), path(samples_tsv) ]
-    somalier_pairs   = SOMALIER_RELATE.out.pairs_tsv                          // channel: [ val(meta), path(pairs_tsv) ]
+    somalier_samples = RELATE_RELATE.out.samples_tsv                          // channel: [ val(meta), path(samples_tsv) ]
+    somalier_pairs   = RELATE_RELATE.out.pairs_tsv                            // channel: [ val(meta), path(pairs_tsv) ]
     versions = ch_versions                                                    // channel: [ versions.yml ]
 }
 

--- a/workflows/nallo.nf
+++ b/workflows/nallo.nf
@@ -233,6 +233,7 @@ workflow NALLO {
         SAMTOOLS_MERGE.out.bam
             .join(SAMTOOLS_MERGE.out.index)
             .concat(bam_to_merge.single)
+            .map { meta, bam, bai -> [ meta - meta.subMap('n_files'), bam, bai ] }
             .set { bam_infer_sex_in }
 
         //


### PR DESCRIPTION
Closes #290 by adding a second somalier relate which is run per sample, on samples with unknown sex. 

This allows variant calling to start right away after alignment and sex check, rather than having to wait for all samples to finish.

<!--
# genomic-medicine-sweden/nallo pull request

Many thanks for contributing to genomic-medicine-sweden/nallo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
