### PR TITLE
Add sample name to TRGT output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.3.0 - [2024-08-28]
+## v0.3.0 - [2024-08-29]
 
 ### `Added`
 
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#323](https://github.com/genomic-medicine-sweden/nallo/pull/323) - Changed `parallel_alignment` to `parallel_alignments` in CI tests as well
 - [#330](https://github.com/genomic-medicine-sweden/nallo/pull/330) - Updated README and version bump
 - [#332](https://github.com/genomic-medicine-sweden/nallo/pull/332) - Changed the PED file input to genmod to include inferred sex from somalier
+- [#333](https://github.com/genomic-medicine-sweden/nallo/pull/333) - Updated TRGT to 0.7.0 and added `meta.id` as output sample name
 
 ### `Removed`
 
@@ -117,6 +118,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | tabix                       | 1.19.1      | 1.20        |
 | echtvar                     | 0.1.7       | 0.2.0       |
 | somalier                    | 0.2.15      | 0.2.18      |
+| TRGT                        | 0.4.0       | 0.7.0       |
 | cadd                        |             | 1.6.post1   |
 | gawk                        |             | 5.3.0       |
 | add_most_severe_consequence |             | v1.0        |

--- a/conf/modules/call_repeat_expansions.config
+++ b/conf/modules/call_repeat_expansions.config
@@ -24,10 +24,12 @@ process {
         ]
     }
 
+    withName: '.*:CALL_REPEAT_EXPANSIONS:TRGT' {
+        ext.args = { "--sample-name ${meta.id}" }
+    }
+
     withName: '.*:CALL_REPEAT_EXPANSIONS:SAMTOOLS_SORT_TRGT' {
-
         ext.prefix = { "${meta.id}_spanning_sorted" }
-
         publishDir = [
             path: { "${params.outdir}/repeat_calling/trgt/single_sample/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -36,7 +38,6 @@ process {
     }
 
     withName: '.*:CALL_REPEAT_EXPANSIONS:SAMTOOLS_INDEX_TRGT' {
-
         publishDir = [
             path: { "${params.outdir}/repeat_calling/trgt/single_sample/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -45,13 +46,11 @@ process {
     }
 
     withName: '.*:CALL_REPEAT_EXPANSIONS:BCFTOOLS_SORT_TRGT' {
-
         ext.prefix = { "${meta.id}_sorted" }
         ext.args = [
             '--output-type z',
             '--write-index=tbi'
         ].join(' ')
-
         publishDir = [
             path: { "${params.outdir}/repeat_calling/trgt/single_sample/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -60,13 +59,11 @@ process {
     }
 
     withName: '.*:CALL_REPEAT_EXPANSIONS:BCFTOOLS_MERGE' {
-
         ext.args = [
             '--output-type z',
             '--write-index=tbi',
             '--force-single'
         ].join(' ')
-
         publishDir = [
             path: { "${params.outdir}/repeat_calling/trgt/multi_sample/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -75,9 +72,7 @@ process {
     }
 
     withName: '.*:CALL_REPEAT_EXPANSIONS:BCFTOOLS_INDEX_MERGE' {
-
         ext.args = '--tbi'
-
         publishDir = [
             path: { "${params.outdir}/repeat_calling/trgt/multi_sample/${meta.id}" },
             mode: params.publish_dir_mode,

--- a/modules/local/trgt/main.nf
+++ b/modules/local/trgt/main.nf
@@ -3,11 +3,12 @@ process TRGT {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "pacbio/trgt:0.4.0"
+    container "biocontainers/trgt:0.7.0--hdfd78af_0"
 
     input:
     tuple val(meta), path(bam), path(bai), val(sex)
     tuple val(meta2), path(fasta)
+    tuple val(meta3), path(fai)
     path(repeats)
 
     output:

--- a/subworkflows/local/call_repeat_expansions/main.nf
+++ b/subworkflows/local/call_repeat_expansions/main.nf
@@ -22,7 +22,7 @@ workflow CALL_REPEAT_EXPANSIONS {
         .set { ch_trgt_input }
 
     // Run TGRT
-    TRGT ( ch_trgt_input, ch_fasta, ch_trgt_bed.map { it[1] } )
+    TRGT ( ch_trgt_input, ch_fasta, ch_fai, ch_trgt_bed.map { it[1] } )
 
     // Sort and index bam
     SAMTOOLS_SORT_TRGT ( TRGT.out.bam, [[],[]] )

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -40,9 +40,9 @@
             "HG002_Revio.regions.bed.gz:md5,e051f64c7a780d67ea6727a327dd4281",
             "HG002_Revio.regions.bed.gz.csi:md5,026eef1c69fb4aa3a1687463fe2088ab",
             "HG002_PacBio_Revio.fastq.gz.tsv.zst:md5,4b073293b3e771d19b4cfdb07909571b",
-            "HG002_Revio_sorted.vcf.gz:md5,bc06de08b8e36b3b48e0d7b9e21df389",
-            "HG002_Revio_sorted.vcf.gz.tbi:md5,08a5c82838264c558eb30726906f47e0",
-            "110181f29066158df34abbad9e3becc8",
+            "HG002_Revio_sorted.vcf.gz:md5,fbb5699b8f74fc105fb154e8fac7bfea",
+            "HG002_Revio_sorted.vcf.gz.tbi:md5,0466518ee265ba63160ed27cee0dec88",
+            "65999ab8f2bc7841de8172468bf23ab6",
             [
                 "# This file was produced by bcftools stats (1.20+htslib-1.20) and can be plotted using plot-vcfstats.",
                 "# The command line was:\tbcftools stats  HG002_Revio.vcf.gz",
@@ -53,7 +53,7 @@
             "nf-test": "0.8.4",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-08-12T09:45:54.652442138"
+        "timestamp": "2024-08-29T10:42:09.011660883"
     },
     "test profile - multisample": {
         "content": [
@@ -92,9 +92,9 @@
             "HG002_Revio_A.regions.bed.gz:md5,e051f64c7a780d67ea6727a327dd4281",
             "HG002_Revio_A.regions.bed.gz.csi:md5,026eef1c69fb4aa3a1687463fe2088ab",
             "HG002_PacBio_Revio.bam_other.fastq.gz.tsv.zst:md5,4b073293b3e771d19b4cfdb07909571b",
-            "HG002_Revio_A_sorted.vcf.gz:md5,b95e709a27fe1df9ee1487b99f396bf4",
-            "HG002_Revio_A_sorted.vcf.gz.tbi:md5,b1eb1f21f36782089b8e0bb0a54105ed",
-            "110181f29066158df34abbad9e3becc8",
+            "HG002_Revio_A_sorted.vcf.gz:md5,680938d6ebeafe73d8df0b21c0310276",
+            "HG002_Revio_A_sorted.vcf.gz.tbi:md5,a6554ab817e7c232a1554ea85fa00151",
+            "65999ab8f2bc7841de8172468bf23ab6",
             [
                 "# This file was produced by bcftools stats (1.20+htslib-1.20) and can be plotted using plot-vcfstats.",
                 "# The command line was:\tbcftools stats  HG002_Revio_A.vcf.gz",
@@ -132,9 +132,9 @@
             "HG002_Revio_B.regions.bed.gz:md5,deaca22783bd058cdc8756efa25b5f53",
             "HG002_Revio_B.regions.bed.gz.csi:md5,dd9a0d36d71da0d274d1c9ca6f8571ae",
             "HG002_Revio_B.merged.fastq.gz.tsv.zst:md5,0641e175a07429b61710329a2eeef450",
-            "HG002_Revio_B_sorted.vcf.gz:md5,05ae66b46d2f87a2133fcdf93d30f38c",
-            "HG002_Revio_B_sorted.vcf.gz.tbi:md5,244a3f966e3434220cd69fcb04b08d01",
-            "18e3bd1fe43fc17ace2f57db5861498c",
+            "HG002_Revio_B_sorted.vcf.gz:md5,ce617741468f4bc7f504f8f488332098",
+            "HG002_Revio_B_sorted.vcf.gz.tbi:md5,e255a5ea92885967f0c126bddc8ea3b2",
+            "6b0cf3f492ce898398835d1102afd369",
             [
                 "# This file was produced by bcftools stats (1.20+htslib-1.20) and can be plotted using plot-vcfstats.",
                 "# The command line was:\tbcftools stats  HG002_Revio_B.vcf.gz",
@@ -145,6 +145,6 @@
             "nf-test": "0.8.4",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-08-28T13:37:54.494547598"
+        "timestamp": "2024-08-29T10:45:44.41793623"
     }
 }


### PR DESCRIPTION
This PR changes the name in the output VCF to `meta.id` instead of taking it from the BAM-file (e.g. changing the sample name from HG002_phased to just HG002). This is required for scout to accept uploads. The `--sample-name` parameter was added in TRGT 0.7.0 and as such an update is needed. 

The TRGT update also requires updating the test-data repeats file (https://github.com/genomic-medicine-sweden/test-datasets/pull/13), as regions in the repeats BED that do not exist in the BAM file/reference now results in errors. 

<!--
# genomic-medicine-sweden/nallo pull request

Many thanks for contributing to genomic-medicine-sweden/nallo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
