### PR TITLE
Fix rank SVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#441](https://github.com/genomic-medicine-sweden/nallo/pull/441) - Changed the minimap2 preset for hifi reads back to `map-hifi`
 - [#443](https://github.com/genomic-medicine-sweden/nallo/pull/443) - Refactored reference channel assignments
 - [#443](https://github.com/genomic-medicine-sweden/nallo/pull/443) - Updated schemas for `vep_plugin_files` and `snp_db`
+- [#479](https://github.com/genomic-medicine-sweden/nallo/pull/479) - Replaced bgzip tabix with bcftools sort in rank variants to fix [#457](https://github.com/genomic-medicine-sweden/nallo/issues/457)
 
 ### `Removed`
 

--- a/conf/modules/rank_variants.config
+++ b/conf/modules/rank_variants.config
@@ -41,6 +41,14 @@ process {
         ext.prefix = { "${meta.id}_snv_genmod_compound" }
         ext.args = "--temp_dir ./"
     }
+    withName: '.*:RANK_VARIANTS_SNV:BCFTOOLS_SORT' {
+        ext.prefix = { "${meta.id}_snv_genmod_compound_sorted" }
+        ext.args = [
+            '--output-type z',
+            '--write-index=tbi',
+            '--max-mem 6G'
+        ].join(' ')
+    }
 
     //
     // Score and rank SVSs
@@ -70,8 +78,13 @@ process {
         ext.prefix = { "${meta.id}_svs_genmod_compound" }
         ext.args = "--temp_dir ./"
     }
-    withName: '.*:RANK_VARIANTS_SVS:TABIX_BGZIPTABIX' {
+    withName: '.*:RANK_VARIANTS_SVS:BCFTOOLS_SORT' {
         ext.prefix = { params.skip_cnv_calling ? "${meta.id}_svs_merged_annotated_ranked" : "${meta.id}_svs_cnvs_merged_annotated_ranked" }
+        ext.args = [
+            '--output-type z',
+            '--write-index=tbi',
+            '--max-mem 6G'
+        ].join(' ')
         publishDir = [
             path: { "${params.outdir}/svs/family/${meta.id}" },
             mode: params.publish_dir_mode,

--- a/subworkflows/local/rank_variants/main.nf
+++ b/subworkflows/local/rank_variants/main.nf
@@ -6,7 +6,7 @@ include { GENMOD_ANNOTATE  } from '../../../modules/nf-core/genmod/annotate/main
 include { GENMOD_MODELS    } from '../../../modules/nf-core/genmod/models/main'
 include { GENMOD_SCORE     } from '../../../modules/nf-core/genmod/score/main'
 include { GENMOD_COMPOUND  } from '../../../modules/nf-core/genmod/compound/main'
-include { TABIX_BGZIPTABIX } from '../../../modules/nf-core/tabix/bgziptabix/main'
+include { BCFTOOLS_SORT    } from '../../../modules/nf-core/bcftools/sort/main'
 
 workflow RANK_VARIANTS {
 
@@ -39,11 +39,11 @@ workflow RANK_VARIANTS {
     GENMOD_COMPOUND ( GENMOD_SCORE.out.vcf )
     ch_versions = ch_versions.mix(GENMOD_COMPOUND.out.versions)
 
-    TABIX_BGZIPTABIX ( GENMOD_COMPOUND.out.vcf )
-    ch_versions = ch_versions.mix(TABIX_BGZIPTABIX.out.versions)
+    BCFTOOLS_SORT ( GENMOD_COMPOUND.out.vcf )
+    ch_versions = ch_versions.mix(BCFTOOLS_SORT.out.versions)
 
     emit:
-    vcf      = TABIX_BGZIPTABIX.out.gz_tbi.map { meta, vcf, tbi -> [ meta, vcf ] } // channel: [ val(meta), path(vcf) ]
-    tbi      = TABIX_BGZIPTABIX.out.gz_tbi.map { meta, vcf, tbi -> [ meta, tbi ] } // channel: [ val(meta), path(tbi) ]
-    versions = ch_versions                                                         // channel: [ path(versions.yml) ]
+    vcf      = BCFTOOLS_SORT.out.vcf // channel: [ val(meta), path(vcf) ]
+    tbi      = BCFTOOLS_SORT.out.tbi // channel: [ val(meta), path(tbi) ]
+    versions = ch_versions           // channel: [ path(versions.yml) ]
 }

--- a/subworkflows/local/rank_variants/tests/main.nf.test.snap
+++ b/subworkflows/local/rank_variants/tests/main.nf.test.snap
@@ -19,7 +19,7 @@
                             "project": null,
                             "contains_affected": false
                         },
-                        "test_data.bed.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "test_data.bed_sorted.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "1": [
@@ -29,15 +29,15 @@
                             "project": null,
                             "contains_affected": false
                         },
-                        "test_data.bed.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_data.bed_sorted.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "2": [
                     "versions.yml:md5,7089dd9c4bcb1dc87f15d3b1a9d5e89d",
+                    "versions.yml:md5,90ddd1e5113e3c0c61c403c53029d0f1",
                     "versions.yml:md5,c9446a89a358fa2126b666399c2c804e",
                     "versions.yml:md5,cc68e7d53d2d24006094e28d37db20a8",
-                    "versions.yml:md5,dd0a9b5a3a16e3bfdcea734de4509dce",
-                    "versions.yml:md5,f56d4e953de59ea23842d33c16e914cf"
+                    "versions.yml:md5,dd0a9b5a3a16e3bfdcea734de4509dce"
                 ],
                 "tbi": [
                     [
@@ -46,7 +46,7 @@
                             "project": null,
                             "contains_affected": false
                         },
-                        "test_data.bed.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_data.bed_sorted.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "vcf": [
@@ -56,15 +56,15 @@
                             "project": null,
                             "contains_affected": false
                         },
-                        "test_data.bed.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "test_data.bed_sorted.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "versions": [
                     "versions.yml:md5,7089dd9c4bcb1dc87f15d3b1a9d5e89d",
+                    "versions.yml:md5,90ddd1e5113e3c0c61c403c53029d0f1",
                     "versions.yml:md5,c9446a89a358fa2126b666399c2c804e",
                     "versions.yml:md5,cc68e7d53d2d24006094e28d37db20a8",
-                    "versions.yml:md5,dd0a9b5a3a16e3bfdcea734de4509dce",
-                    "versions.yml:md5,f56d4e953de59ea23842d33c16e914cf"
+                    "versions.yml:md5,dd0a9b5a3a16e3bfdcea734de4509dce"
                 ]
             }
         ],
@@ -72,6 +72,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-29T09:06:31.363029566"
+        "timestamp": "2024-11-01T13:03:00.102392544"
     }
 }

--- a/subworkflows/local/rank_variants/tests/nextflow.config
+++ b/subworkflows/local/rank_variants/tests/nextflow.config
@@ -114,4 +114,9 @@ process {
         ext.prefix = { "${meta.id}_genmod_compound" }
         ext.args = "--temp_dir ./"
     }
+
+    withName: 'RANK_VARIANTS:BCFTOOLS_SORT' {
+        ext.prefix = { "${meta.id}_sorted" }
+        ext.args = "--output-type z --write-index=tbi"
+    }
 }


### PR DESCRIPTION
Closes #457. This is really a genmod problem, but adding a bcftools sort to the rank variants subworkflow solves it temporarily. When genmod has been updated, bcftools sort should be removed. 

<!--
# genomic-medicine-sweden/nallo pull request

Many thanks for contributing to genomic-medicine-sweden/nallo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
