### PR TITLE
nf-test with changed-since

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+      - name: Fetch ${{ github.event.pull_request.base.ref }} branch
+        run: |
+          git remote add upstream ${{ github.event.repository.clone_url }}
+          git fetch upstream ${{ github.event.pull_request.base.ref }}
 
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v2
@@ -73,21 +79,10 @@ jobs:
 
       - name: Run nf-test
         run: |
-          nf-test test --verbose --tag ${{ matrix.tags }} --profile "+${{ matrix.profile }}" --junitxml=test.xml --tap=test.tap
-
-      - uses: pcolby/tap-summary@v1
-        with:
-          path: >-
-            test.tap
-
-      - name: Output log on failure
-        if: failure()
-        run: |
-          sudo apt install bat > /dev/null
-          batcat --decorations=always --color=always ${{ github.workspace }}/.nf-test/tests/*/meta/nextflow.log
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        if: always() # always run even if the previous step fails
-        with:
-          report_paths: test.xml
+          nf-test test \
+            --ci \
+            --changed-since upstream/${{ github.event.pull_request.base.ref }} \
+            --verbose \
+            --tag ${{ matrix.tags }} \
+            --profile "+${{ matrix.profile }}" \
+            --junitxml=test.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   NXF_ANSI_LOG: false
-  NFTEST_VER: "0.9.0"
+  NFTEST_VER: "0.9.2"
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#474](https://github.com/genomic-medicine-sweden/nallo/pull/474) - Updated VEP and CADD channels to fix bugs introduced in [#443](https://github.com/genomic-medicine-sweden/nallo/pull/443)
 - [#479](https://github.com/genomic-medicine-sweden/nallo/pull/479) - Replaced bgzip tabix with bcftools sort in rank variants to fix [#457](https://github.com/genomic-medicine-sweden/nallo/issues/457)
 - [#484](https://github.com/genomic-medicine-sweden/nallo/pull/484) - Updated metro map and added SVG version
+- [#487](https://github.com/genomic-medicine-sweden/nallo/pull/487) - Changed CI tests to only run tests where changes have been made
 
 ### `Removed`
 

--- a/subworkflows/local/annotate_svs/main.nf
+++ b/subworkflows/local/annotate_svs/main.nf
@@ -14,7 +14,7 @@ workflow ANNOTATE_SVS {
 
     main:
     ch_versions = Channel.empty()
-
+    ch_versions.view()
     ch_sv_dbs
         .map { meta, csv -> csv }
         .splitCsv ( header:true )

--- a/subworkflows/local/annotate_svs/main.nf
+++ b/subworkflows/local/annotate_svs/main.nf
@@ -14,7 +14,7 @@ workflow ANNOTATE_SVS {
 
     main:
     ch_versions = Channel.empty()
-    ch_versions.view()
+
     ch_sv_dbs
         .map { meta, csv -> csv }
         .splitCsv ( header:true )


### PR DESCRIPTION
This PR incorporates the `changed-since` command in the CI-tests, fixed in nf-test 0.9.2. This makes tests run only if changes have been made in that test.

One thing further would be to skip the tags completely and rely on shards, but there's no easy way to see which tests are run in a shard yet, so I will leave this to another PR. 

<!--
# genomic-medicine-sweden/nallo pull request

Many thanks for contributing to genomic-medicine-sweden/nallo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
