### PR TITLE
Dynamically build methods description from ch_versions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -73,7 +73,8 @@ If you wish to contribute a new step, please use the following coding standards:
 7. Perform local tests to validate that the new code works as expected.
 8. If applicable, add a new test command in `.github/workflow/ci.yml`.
 9. Update MultiQC config `assets/multiqc_config.yml` so relevant suffixes, file name clean up and module plots are in the appropriate order. If applicable, add a [MultiQC](https://https://multiqc.info/) module.
-10. Add a description of the output files and if relevant any appropriate images from the MultiQC report to `docs/output.md`.
+10. Update the tool references `assets/software_references.yml`.
+11. Add a description of the output files and if relevant any appropriate images from the MultiQC report to `docs/output.md`.
 
 ### Default values
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#506](https://github.com/genomic-medicine-sweden/nallo/pull/506) - Updated documentation
 - [#507](https://github.com/genomic-medicine-sweden/nallo/pull/507) - Changed the default value of `ch_hgnc_ids` to allow running without `--filter_variants_hgnc_ids` introduced in [#496](https://github.com/genomic-medicine-sweden/nallo/pull/443)
 - [#509](https://github.com/genomic-medicine-sweden/nallo/pull/509) - Updated documentation to fix mistakes
+- [#510](https://github.com/genomic-medicine-sweden/nallo/pull/510) - Changed the MultiQC methods description to update dynamically based on `ch_versions`
 
 ### `Removed`
 

--- a/assets/methods_description_template.yml
+++ b/assets/methods_description_template.yml
@@ -5,5 +5,14 @@ section_href: "https://github.com/genomic-medicine-sweden/nallo"
 plot_type: "html"
 data: |
   <h4>Methods</h4>
-  <p>Data was processed using genomic-medicine-sweden/nallo v${workflow.manifest.version} ${doi_text} which uses uses code and infrastructure developed and maintained by the nf-core community, reused here under the [MIT license](https://github.com/nf-core/tools/blob/master/LICENSE) (<a href="https://doi.org/10.1038/s41587-020-0439-x">Ewels <em>et al.</em>, 2020</a>), utilising reproducible software environments from the Bioconda (<a href="https://doi.org/10.1038/s41592-018-0046-7">Grüning <em>et al.</em>, 2018</a>) and Biocontainers (<a href="https://doi.org/10.1093/bioinformatics/btx192">da Veiga Leprevost <em>et al.</em>, 2017</a>) projects.</p>
+  <p>Data was processed using genomic-medicine-sweden/nallo v${workflow.manifest.version} ${doi_text} which uses uses code and infrastructure developed and maintained by the nf-core community, reused here under the <a href="https://github.com/nf-core/tools/blob/master/LICENSE">MIT licence</a> (<a href="https://doi.org/10.1038/s41587-020-0439-x">Ewels <em>et al.</em>, 2020</a>), utilising reproducible software environments from the Bioconda (<a href="https://doi.org/10.1038/s41592-018-0046-7">Grüning <em>et al.</em>, 2018</a>) and Biocontainers (<a href="https://doi.org/10.1093/bioinformatics/btx192">da Veiga Leprevost <em>et al.</em>, 2017</a>) projects.</p>
   <p>The pipeline was executed with Nextflow v${workflow.nextflow.version} (<a href="https://doi.org/10.1038/nbt.3820">Di Tommaso <em>et al.</em>, 2017</a>) with the following command:</p>
+  <pre><code>${workflow.commandLine}</code></pre>
+  <div class="alert alert-info">
+    <h5>Notes:</h5>
+    <ul>
+      ${nodoi_text}
+      <li>The command above does not include parameters contained in any configs or profiles that may have been used. Ensure the config file is also uploaded with your publication!</li>
+      <li>You should also cite all software used within this run. Check the "Software Versions" of this report to get version information.</li>
+    </ul>
+  </div>

--- a/assets/software_references.yml
+++ b/assets/software_references.yml
@@ -1,0 +1,139 @@
+tool:
+  nextflow:
+    citation: ""
+    bibliography: 'Di Tommaso, P., Chatzou, M., Floden, E. W., Barja, P. P., Palumbo, E., & Notredame, C. (2017). Nextflow enables reproducible computational workflows. Nature Biotechnology, 35(4), 316-319. doi: <a href="https://doi.org/10.1038/nbt.3820">10.1038/nbt.3820</a>'
+  nf_core:
+    citation: ""
+    bibliography: 'Di Tommaso, P., Chatzou, M., Floden, E. W., Barja, P. P., Palumbo, E., & Notredame, C. (2017). Nextflow enables reproducible computational workflows. Nature Biotechnology, 35(4), 316-319. doi: <a href="https://doi.org/10.1038/nbt.3820">10.1038/nbt.3820</a>'
+  bioconda:
+    citation: ""
+    bibliography: 'Grüning, B., Dale, R., Sjödin, A., Chapman, B. A., Rowe, J., Tomkins-Tinch, C. H., Valieris, R., Köster, J., & Bioconda Team. (2018). Bioconda: sustainable and comprehensive software distribution for the life sciences. Nature Methods, 15(7), 475–476. doi: <a href="https://doi.org/10.1038/s41592-018-0046-7">10.1038/s41592-018-0046-7</a>'
+  biocontainers:
+    citation: ""
+    bibliography: 'da Veiga Leprevost, F., Grüning, B. A., Alves Aflitos, S., Röst, H. L., Uszkoreit, J., Barsnes, H., Vaudel, M., Moreno, P., Gatto, L., Weber, J., Bai, M., Jimenez, R. C., Sachsenberg, T., Pfeuffer, J., Vera Alvarez, R., Griss, J., Nesvizhskii, A. I., & Perez-Riverol, Y. (2017). BioContainers: an open-source and community-driven framework for software standardization. Bioinformatics (Oxford, England), 33(16), 2580–2582. doi: <a href="https://doi.org/10.1093/bioinformatics/btx192">10.1093/bioinformatics/btx192</a>'
+  multiqc:
+    citation: "MultiQC (Ewels et al. 2016)"
+    bibliography: "Ewels P, Magnusson M, Lundin S, Käller M. MultiQC: summarize analysis results for multiple tools and samples in a single report. Bioinformatics. 2016 Oct 1;32(19):3047-8. doi: 10.1093/bioinformatics/btw354. Epub 2016 Jun 16. PMID: 27312411; PMCID: PMC5039924."
+  add_most_severe_consequence:
+    citation: "add_most_severe_consequence (Neethiraj 2022)"
+    bibliography: ""
+  add_most_severe_pli:
+    citation: "add_most_severe_pli (Neethiraj 2022)"
+    bibliography: ""
+  bcftools:
+    citation: "BCFtools (Danecek et al. 2021)"
+    bibliography: "Danecek P, Bonfield JK, Liddle J, et al. Twelve years of SAMtools and BCFtools. GigaScience. 2021;10(2):giab008. doi:10.1093/gigascience/giab008"
+  bedtools:
+    citation: "BEDTools (Quinlan & Hall 2010)"
+    bibliography: "Quinlan AR and Hall IM, 2010. BEDTools: a flexible suite of utilities for comparing genomic features. Bioinformatics. 26, 6, pp. 841–842."
+  bgzip:
+    citation: "bgzip"
+    bibliography: ""
+  busybox_awk:
+    citation: "BusyBox's awk"
+    bibliography: ""
+  cadd:
+    citation: "CADD (Rentzsch et al. 2019, Rentzsch et al. 2021)"
+    bibliography: "Rentzsch P, Schubach M, Shendure J, Kircher M. CADD-Splice—improving genome-wide variant effect prediction using deep learning-derived splice scores. Genome Med. 2021;13(1):31. doi:10.1186/s13073-021-00835-9"
+  cramino:
+    citation: "cramino (De Coster & Rademakers 2023)"
+    bibliography: "Wouter De Coster, Rosa Rademakers, NanoPack2: population-scale evaluation of long-read sequencing data, Bioinformatics, Volume 39, Issue 5, May 2023, btad311, https://doi.org/10.1093/bioinformatics/btad311"
+  create_pedigree_file:
+    citation: "create_pedigree_file"
+    bibliography: ""
+  deepvariant:
+    citation: "DeepVariant (Poplin et al. 2018)"
+    bibliography: "Poplin R, Chang PC, Alexander D, et al. A universal SNP and small-indel variant caller using deep neural networks. Nat Biotechnol. 2018;36(10):983-987. doi:10.1038/nbt.4235"
+  dipcall:
+    citation: "dipcall (Li et al. 2018)"
+    bibliography: "Li H, Bloom JM, Farjoun Y, Fleharty M, Gauthier L, Neale B, MacArthur D (2018) A synthetic-diploid benchmark for accurate variant-calling evaluation. Nat Methods, 15:595-597. [PMID:30013044]"
+  echtvar:
+    citation: "Echtvar (Pedersen & de Ridder 2023)"
+    bibliography: "Brent S Pedersen, Jeroen de Ridder, Echtvar: compressed variant representation for rapid annotation and filtering of SNPs and indels, Nucleic Acids Research, Volume 51, Issue 1, 11 January 2023, Page e3, https://doi.org/10.1093/nar/gkac931"
+  ensemblvep:
+    citation: "VEP (McLaren et al. 2016)"
+    bibliography: "McLaren W, Gil L, Hunt SE, et al. The Ensembl Variant Effect Predictor. Genome Biol. 2016;17(1):122. doi:10.1186/s13059-016-0974-4"
+  fastqc:
+    citation: "FastQC (Andrews 2010)"
+    bibliography: "Andrews S, (2010) FastQC, URL: https://www.bioinformatics.babraham.ac.uk/projects/fastqc/"
+  gawk:
+    citation: "gawk"
+    bibliography: ""
+  genmod:
+    citation: "Genmod (Magnusson et al. 2018)"
+    bibliography: "Magnusson M, Hughes T, Glabilloy, Bitdeli Chef. genmod: Version 3.7.3. Published online November 15, 2018. doi:10.5281/ZENODO.3841142"
+  gfastats:
+    citation: "Gfastats (Formenti et al. 2022)"
+    bibliography: "Giulio Formenti, Linelle Abueg, Angelo Brajuka, Nadolina Brajuka, Cristóbal Gallardo-Alba, Alice Giani, Olivier Fedrigo, Erich D Jarvis, Gfastats: conversion, evaluation and manipulation of genome sequences using assembly graphs, Bioinformatics, Volume 38, Issue 17, September 2022, Pages 4214–4216, https://doi.org/10.1093/bioinformatics/btac460"
+  glnexus:
+    citation: "GLnexus (Yun et al. 2021)"
+    bibliography: "Yun T, Li H, Chang PC, Lin MF, Carroll A, McLean CY. Accurate, scalable cohort variant calls using DeepVariant and GLnexus. Robinson P, ed. Bioinformatics. 2021;36(24):5582-5589. doi:10.1093/bioinformatics/btaa1081"
+  gunzip:
+    citation: "gunzip"
+    bibliography: ""
+  hifiasm:
+    citation: "Hifiasm (Cheng et al. 2021)"
+    bibliography: "Cheng, H., Concepcion, G.T., Feng, X. et al. Haplotype-resolved de novo assembly using phased assembly graphs with hifiasm. Nat Methods 18, 170–175 (2021). https://doi.org/10.1038/s41592-020-01056-5"
+  hificnv:
+    citation: "HiFiCNV"
+    bibliography: ""
+  hiphase:
+    citation: "HiPhase (Holt et al. 2024)"
+    bibliography: "James M Holt, Christopher T Saunders, William J Rowell, Zev Kronenberg, Aaron M Wenger, Michael Eberle, HiPhase: jointly phasing small, structural, and tandem repeat variants from HiFi sequencing, Bioinformatics, Volume 40, Issue 2, February 2024, btae042, https://doi.org/10.1093/bioinformatics/btae042"
+  longphase:
+    citation: "LongPhase (Lin et al. 2024)"
+    bibliography: "Jyun-Hong Lin, Liang-Chi Chen, Shu-Chi Yu, Yao-Ting Huang, LongPhase: an ultra-fast chromosome-scale phasing algorithm for small and large variants, Bioinformatics, Volume 38, Issue 7, March 2022, Pages 1816–1822, https://doi.org/10.1093/bioinformatics/btac058"
+  minimap2:
+    citation: "Minimap2 (Li 2018)"
+    bibliography: "Heng Li, Minimap2: pairwise alignment for nucleotide sequences, Bioinformatics, Volume 34, Issue 18, September 2018, Pages 3094–3100, https://doi.org/10.1093/bioinformatics/bty191"
+  modkit:
+    citation: "modkit"
+    bibliography: ""
+  mosdepth:
+    citation: "mosdepth (Pedersen & Quinlan 2018)"
+    bibliography: "Pedersen BS, Quinlan AR. Mosdepth: quick coverage calculation for genomes and exomes. Hancock J, ed. Bioinformatics. 2018;34(5):867-868. doi:10.1093/bioinformatics/btx699"
+  paraphase:
+    citation: "Paraphase (Chen et al. 2023)"
+    bibliography: "Genome-wide profiling of highly similar paralogous genes using HiFi sequencing. Xiao Chen, Daniel Baker, Egor Dolzhenko, Joseph M Devaney, Jessica Noya, April S Berlyoung, Rhonda Brandon, Kathleen S Hruska, Lucas Lochovsky, Paul Kruszka, Scott Newman, Emily Farrow, Isabelle Thiffault, Tomi Pastinen, Dalia Kasperaviciute, Christian Gilissen, Lisenka Vissers, Alexander Hoischen, Seth Berger, Eric Vilain, Emmanuèle Délot, UCI Genomics Research to Elucidate the Genetics of Rare Diseases (UCI GREGoR) Consortium, Michael A Eberle. bioRxiv 2024.04.19.590294; doi: https://doi.org/10.1101/2024.04.19.590294"
+  python:
+    citation: "Python (Van Rossum & Drake Jr 2009)"
+    bibliography: ""
+  samtools:
+    citation: "SAMtools (Danecek et al. 2021)"
+    bibliography: "Danecek P, Bonfield JK, Liddle J, et al. Twelve years of SAMtools and BCFtools. GigaScience. 2021;10(2):giab008. doi:10.1093/gigascience/giab008"
+  sniffles:
+    citation: "Sniffles2 (Smolka et al. 2024)"
+    bibliography: "Smolka, M., Paulin, L.F., Grochowski, C.M. et al. Detection of mosaic and population-level structural variants with Sniffles2. Nat Biotechnol (2024). https://doi.org/10.1038/s41587-023-02024-y"
+  severus:
+    citation: "Severus (Keskus et al. 2024)"
+    bibliography: "Ayse Keskus, Asher Bryant, Tanveer Ahmad, Byunggil Yoo, Sergey Aganezov, Anton Goretsky, Ataberk Donmez, Lisa A. Lansdon, Isabel Rodriguez, Jimin Park, Yuelin Liu, Xiwen Cui, Joshua Gardner, Brandy McNulty, Samuel Sacco, Jyoti Shetty, Yongmei Zhao, Bao Tran, Giuseppe Narzisi, Adrienne Helland, Daniel E. Cook, Pi-Chuan Chang, Alexey Kolesnikov, Andrew Carroll, Erin K. Molloy, Irina Pushel, Erin Guest, Tomi Pastinen, Kishwar Shafin, Karen H. Miga, Salem Malikic, Chi-Ping Day, Nicolas Robine, Cenk Sahinalp, Michael Dean, Midhat S. Farooqi, Benedict Paten, Mikhail Kolmogorov. Severus: accurate detection and characterization of somatic structural variation in tumor genomes using long reads. medRxiv 2024.03.22.24304756; doi: https://doi.org/10.1101/2024.03.22.24304756"
+  somalier:
+    citation: "Somalier (Pedersen et al. 2020)"
+    bibliography: "Pedersen, B.S., Bhetariya, P.J., Brown, J. et al. Somalier: rapid relatedness estimation for cancer and germline studies using efficient genome sketches. Genome Med 12, 62 (2020). https://doi.org/10.1186/s13073-020-00761-2"
+  split_bed_chunks:
+    citation: "split_bed_chunks"
+    bibliography: ""
+  splitubam:
+    citation: "splitubam"
+    bibliography: ""
+  stranger:
+    citation: "Stranger (Nilsson & Magnusson 2021)"
+    bibliography: "Nilsson D, Magnusson M. moonso/stranger v0.7.1. Published online February 18, 2021. doi:10.5281/ZENODO.4548873"
+  svdb:
+    citation: "SVDB (Eisfeldt et al. 2017)"
+    bibliography: ""
+  tabix:
+    citation: "Tabix (Li 2011)"
+    bibliography: "Li H. Tabix: fast retrieval of sequence features from generic TAB-delimited files. Bioinformatics. 2011;27(5):718-719. doi:10.1093/bioinformatics/btq671"
+  trgt:
+    citation: "TRGT (Dolzhenko et al. 2024)"
+    bibliography: "Dolzhenko, E., English, A., Dashnow, H. et al. Characterization and visualization of tandem repeats at genome scale. Nat Biotechnol (2024). https://doi.org/10.1038/s41587-023-02057-3"
+  untar:
+    citation: "untar"
+    bibliography: ""
+  yak:
+    citation: "yak"
+    bibliography: ""
+  whatshap:
+    citation: "WhatsHap (Martin et al. 2016)"
+    bibliography: "Marcel Martin, Murray Patterson, Shilpa Garg, Sarah O Fischer, Nadia Pisanti, Gunnar W Klau, Alexander Schöenhuth, Tobias Marschall. bioRxiv 085050; doi: https://doi.org/10.1101/085050"

--- a/modules/local/add_found_in_tag/main.nf
+++ b/modules/local/add_found_in_tag/main.nf
@@ -64,7 +64,7 @@ process ADD_FOUND_IN_TAG {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         bcftools: \$(bcftools --version 2>&1 | head -n1 | sed 's/^.*bcftools //; s/ .*\$//')
-        busybox-awk: \$(awk 2>&1 | sed -n 's/.*v\\([^ ]*\\) (.*/\\1/p')
+        busybox_awk: \$(awk 2>&1 | sed -n 's/.*v\\([^ ]*\\) (.*/\\1/p')
     END_VERSIONS
     """
 
@@ -90,7 +90,7 @@ process ADD_FOUND_IN_TAG {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         bcftools: \$(bcftools --version 2>&1 | head -n1 | sed 's/^.*bcftools //; s/ .*\$//')
-        busybox-awk: \$(awk 2>&1 | sed -n 's/.*v\\([^ ]*\\) (.*/\\1/p')
+        busybox_awk: \$(awk 2>&1 | sed -n 's/.*v\\([^ ]*\\) (.*/\\1/p')
     END_VERSIONS
     """
 }

--- a/subworkflows/local/call_svs/tests/main.nf.test.snap
+++ b/subworkflows/local/call_svs/tests/main.nf.test.snap
@@ -43,8 +43,8 @@
                     "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                     "versions.yml:md5,589fd8607c7131f786d565deb2846f0c",
                     "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                    "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                     "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                    "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                     "versions.yml:md5,d6665112b721f1651ae340c644f9a27c"
                 ],
                 "family_tbi": [
@@ -88,8 +88,8 @@
                     "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                     "versions.yml:md5,589fd8607c7131f786d565deb2846f0c",
                     "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                    "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                     "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                    "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                     "versions.yml:md5,d6665112b721f1651ae340c644f9a27c"
                 ]
             }
@@ -98,7 +98,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:48:16.872760798"
+        "timestamp": "2024-11-21T14:29:03.235235925"
     },
     "2 samples - [bam, bai], fasta, fai, [], [] - sniffles -stub": {
         "content": [
@@ -145,10 +145,10 @@
                 "versions.yml:md5,589fd8607c7131f786d565deb2846f0c",
                 "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
                 "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
-                "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                 "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
                 "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
+                "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                 "versions.yml:md5,d6665112b721f1651ae340c644f9a27c"
             ]
         ],
@@ -156,7 +156,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:48:47.623104856"
+        "timestamp": "2024-11-21T14:29:33.316947597"
     },
     "1 sample - [bam, bai], fasta, fai, [], [] - sniffles -stub": {
         "content": [
@@ -202,8 +202,8 @@
                     "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                     "versions.yml:md5,589fd8607c7131f786d565deb2846f0c",
                     "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                    "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                     "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                    "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                     "versions.yml:md5,d6665112b721f1651ae340c644f9a27c"
                 ],
                 "family_tbi": [
@@ -247,8 +247,8 @@
                     "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                     "versions.yml:md5,589fd8607c7131f786d565deb2846f0c",
                     "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                    "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                     "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                    "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                     "versions.yml:md5,d6665112b721f1651ae340c644f9a27c"
                 ]
             }
@@ -257,7 +257,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:48:01.475015636"
+        "timestamp": "2024-11-21T14:28:47.871974459"
     },
     "1 sample - [bam, bai], fasta, fai, [], [] - severus": {
         "content": [
@@ -269,8 +269,8 @@
                 "versions.yml:md5,0c2f48bb23bdcc814171177730552a0b",
                 "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                 "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                 "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                 "versions.yml:md5,d6665112b721f1651ae340c644f9a27c",
                 "versions.yml:md5,dab46ec91d22db3eee78879773b88f1f"
             ]
@@ -279,7 +279,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:46:16.434467252"
+        "timestamp": "2024-11-21T14:27:02.494989112"
     },
     "1 sample - [bam, bai], fasta, fai, [], bed - severus -stub": {
         "content": [
@@ -324,8 +324,8 @@
                     "versions.yml:md5,0c2f48bb23bdcc814171177730552a0b",
                     "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                     "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                    "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                     "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                    "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                     "versions.yml:md5,d6665112b721f1651ae340c644f9a27c",
                     "versions.yml:md5,dab46ec91d22db3eee78879773b88f1f"
                 ],
@@ -369,8 +369,8 @@
                     "versions.yml:md5,0c2f48bb23bdcc814171177730552a0b",
                     "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                     "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                    "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                     "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                    "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                     "versions.yml:md5,d6665112b721f1651ae340c644f9a27c",
                     "versions.yml:md5,dab46ec91d22db3eee78879773b88f1f"
                 ]
@@ -380,7 +380,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:49:16.762933068"
+        "timestamp": "2024-11-21T14:30:02.236874166"
     },
     "1 sample - [bam, bai], fasta, fai, [], bed - severus": {
         "content": [
@@ -392,8 +392,8 @@
                 "versions.yml:md5,0c2f48bb23bdcc814171177730552a0b",
                 "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                 "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                 "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                 "versions.yml:md5,d6665112b721f1651ae340c644f9a27c",
                 "versions.yml:md5,dab46ec91d22db3eee78879773b88f1f"
             ]
@@ -402,7 +402,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:46:53.615376875"
+        "timestamp": "2024-11-21T14:27:40.147457805"
     },
     "2 samples - [bam, bai], fasta, fai, [], [] - sniffles": {
         "content": [
@@ -810,10 +810,10 @@
                 "versions.yml:md5,589fd8607c7131f786d565deb2846f0c",
                 "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
                 "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
-                "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                 "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
                 "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
+                "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                 "versions.yml:md5,d6665112b721f1651ae340c644f9a27c"
             ]
         ],
@@ -821,7 +821,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-29T08:25:17.479785577"
+        "timestamp": "2024-11-21T14:26:28.586336982"
     },
     "1 sample - [bam, bai], fasta, fai, [], bed - sniffles -stub": {
         "content": [
@@ -867,8 +867,8 @@
                     "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                     "versions.yml:md5,589fd8607c7131f786d565deb2846f0c",
                     "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                    "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                     "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                    "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                     "versions.yml:md5,d6665112b721f1651ae340c644f9a27c"
                 ],
                 "family_tbi": [
@@ -912,8 +912,8 @@
                     "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                     "versions.yml:md5,589fd8607c7131f786d565deb2846f0c",
                     "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                    "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                     "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                    "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                     "versions.yml:md5,d6665112b721f1651ae340c644f9a27c"
                 ]
             }
@@ -922,7 +922,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:48:31.835006564"
+        "timestamp": "2024-11-21T14:29:17.841219039"
     },
     "1 sample - [bam, bai], fasta, fai, [], [] - severus -stub": {
         "content": [
@@ -967,8 +967,8 @@
                     "versions.yml:md5,0c2f48bb23bdcc814171177730552a0b",
                     "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                     "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                    "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                     "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                    "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                     "versions.yml:md5,d6665112b721f1651ae340c644f9a27c",
                     "versions.yml:md5,dab46ec91d22db3eee78879773b88f1f"
                 ],
@@ -1012,8 +1012,8 @@
                     "versions.yml:md5,0c2f48bb23bdcc814171177730552a0b",
                     "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                     "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                    "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                     "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                    "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                     "versions.yml:md5,d6665112b721f1651ae340c644f9a27c",
                     "versions.yml:md5,dab46ec91d22db3eee78879773b88f1f"
                 ]
@@ -1023,7 +1023,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:49:02.270018205"
+        "timestamp": "2024-11-21T14:29:47.72768953"
     },
     "1 sample - [bam, bai], fasta, fai, [], [] - sniffles": {
         "content": [
@@ -1034,8 +1034,8 @@
                 "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                 "versions.yml:md5,589fd8607c7131f786d565deb2846f0c",
                 "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                 "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                 "versions.yml:md5,d6665112b721f1651ae340c644f9a27c"
             ]
         ],
@@ -1043,7 +1043,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:45:02.833173008"
+        "timestamp": "2024-11-21T14:25:50.038358587"
     },
     "1 sample - [bam, bai], fasta, fai, bed, [] - severus": {
         "content": [
@@ -1055,8 +1055,8 @@
                 "versions.yml:md5,0c2f48bb23bdcc814171177730552a0b",
                 "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                 "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                 "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                 "versions.yml:md5,d6665112b721f1651ae340c644f9a27c",
                 "versions.yml:md5,dab46ec91d22db3eee78879773b88f1f"
             ]
@@ -1065,7 +1065,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:46:35.586319077"
+        "timestamp": "2024-11-21T14:27:21.812768584"
     },
     "1 sample - [bam, bai], fasta, fai, [], bed - sniffles": {
         "content": [
@@ -1076,8 +1076,8 @@
                 "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                 "versions.yml:md5,589fd8607c7131f786d565deb2846f0c",
                 "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                 "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                 "versions.yml:md5,d6665112b721f1651ae340c644f9a27c"
             ]
         ],
@@ -1085,7 +1085,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:45:58.327508015"
+        "timestamp": "2024-11-21T14:26:44.491561807"
     },
     "2 samples - [bam, bai], fasta, fai, [], [] - severus -stub": {
         "content": [
@@ -1130,10 +1130,10 @@
                 "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                 "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
                 "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
-                "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                 "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
                 "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
+                "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                 "versions.yml:md5,d6665112b721f1651ae340c644f9a27c",
                 "versions.yml:md5,dab46ec91d22db3eee78879773b88f1f",
                 "versions.yml:md5,dab46ec91d22db3eee78879773b88f1f"
@@ -1143,7 +1143,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:49:46.640106268"
+        "timestamp": "2024-11-21T14:30:32.349238883"
     },
     "1 sample - [bam, bai], fasta, fai, bed, [] - severus -stub": {
         "content": [
@@ -1188,8 +1188,8 @@
                     "versions.yml:md5,0c2f48bb23bdcc814171177730552a0b",
                     "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                     "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                    "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                     "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                    "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                     "versions.yml:md5,d6665112b721f1651ae340c644f9a27c",
                     "versions.yml:md5,dab46ec91d22db3eee78879773b88f1f"
                 ],
@@ -1233,8 +1233,8 @@
                     "versions.yml:md5,0c2f48bb23bdcc814171177730552a0b",
                     "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                     "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                    "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                     "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                    "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                     "versions.yml:md5,d6665112b721f1651ae340c644f9a27c",
                     "versions.yml:md5,dab46ec91d22db3eee78879773b88f1f"
                 ]
@@ -1244,7 +1244,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:49:31.495665136"
+        "timestamp": "2024-11-21T14:30:16.946977312"
     },
     "2 samples - [bam, bai], fasta, fai, [], [] - severus": {
         "content": [
@@ -1260,10 +1260,10 @@
                 "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                 "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
                 "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
-                "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                 "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
                 "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
+                "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                 "versions.yml:md5,d6665112b721f1651ae340c644f9a27c",
                 "versions.yml:md5,dab46ec91d22db3eee78879773b88f1f",
                 "versions.yml:md5,dab46ec91d22db3eee78879773b88f1f"
@@ -1273,7 +1273,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:47:46.540905608"
+        "timestamp": "2024-11-21T14:28:33.091100608"
     },
     "1 sample - [bam, bai], fasta, fai, bed, [] - sniffles": {
         "content": [
@@ -1286,8 +1286,8 @@
                 "versions.yml:md5,110bc7290a8aa06aea1c1fd2bad26324",
                 "versions.yml:md5,589fd8607c7131f786d565deb2846f0c",
                 "versions.yml:md5,7090d52a64ab671fdb51c6af429628f4",
-                "versions.yml:md5,80c39296f4a0ebb7f53a6ea4819c1fd9",
                 "versions.yml:md5,ad7a1d3e0b9738f34f6f4cf8c7a5a7ff",
+                "versions.yml:md5,cff333ea42eb748bf5dcc2c2a7d59c5f",
                 "versions.yml:md5,d6665112b721f1651ae340c644f9a27c"
             ]
         ],
@@ -1295,6 +1295,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T09:45:20.394200452"
+        "timestamp": "2024-11-21T14:26:07.339172165"
     }
 }

--- a/subworkflows/local/short_variant_calling/tests/main.nf.test.snap
+++ b/subworkflows/local/short_variant_calling/tests/main.nf.test.snap
@@ -52,10 +52,10 @@
                     "versions.yml:md5,77dbd5f16ae8b59d09563a07be6faa44",
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ],
                 "family_bcf": [
                     [
@@ -107,10 +107,10 @@
                     "versions.yml:md5,77dbd5f16ae8b59d09563a07be6faa44",
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ]
             }
         ],
@@ -118,7 +118,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-12T18:13:18.281203796"
+        "timestamp": "2024-11-21T14:31:35.224934094"
     },
     "1 sample - 2 bed, fasta, fai, bed, [] - stub": {
         "content": [
@@ -189,13 +189,13 @@
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ],
                 "family_bcf": [
                     [
@@ -263,13 +263,13 @@
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ]
             }
         ],
@@ -277,7 +277,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-12T18:16:17.601722369"
+        "timestamp": "2024-11-21T14:34:35.379604763"
     },
     "1 sample - 1 bed, fasta, fai, bed, []": {
         "content": [
@@ -332,10 +332,10 @@
                     "versions.yml:md5,77dbd5f16ae8b59d09563a07be6faa44",
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ],
                 "family_bcf": [
                     [
@@ -387,10 +387,10 @@
                     "versions.yml:md5,77dbd5f16ae8b59d09563a07be6faa44",
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ]
             }
         ],
@@ -398,7 +398,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-12T18:13:48.779934595"
+        "timestamp": "2024-11-21T14:32:05.96601253"
     },
     "2 samples - 2 bed, fasta, fai, bed, par_bed": {
         "content": [
@@ -492,8 +492,6 @@
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
@@ -501,7 +499,9 @@
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ],
                 "family_bcf": [
                     [
@@ -592,8 +592,6 @@
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
@@ -601,7 +599,9 @@
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ]
             }
         ],
@@ -609,7 +609,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-12T18:15:32.090234345"
+        "timestamp": "2024-11-21T14:33:48.773081634"
     },
     "2 samples - 2 bed, fasta, fai, bed, [] - stub": {
         "content": [
@@ -703,8 +703,6 @@
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
@@ -712,7 +710,9 @@
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ],
                 "family_bcf": [
                     [
@@ -803,8 +803,6 @@
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
@@ -812,7 +810,9 @@
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ]
             }
         ],
@@ -820,7 +820,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-12T18:16:31.350382929"
+        "timestamp": "2024-11-21T14:34:48.741504128"
     },
     "2 samples - 2 bed, fasta, fai, bed, par_bed - stub": {
         "content": [
@@ -914,8 +914,6 @@
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
@@ -923,7 +921,9 @@
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ],
                 "family_bcf": [
                     [
@@ -1014,8 +1014,6 @@
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
@@ -1023,7 +1021,9 @@
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ]
             }
         ],
@@ -1031,7 +1031,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-12T18:16:44.845313016"
+        "timestamp": "2024-11-21T14:35:02.231722564"
     },
     "1 sample - 1 bed, fasta, fai, bed, [] - stub": {
         "content": [
@@ -1086,10 +1086,10 @@
                     "versions.yml:md5,77dbd5f16ae8b59d09563a07be6faa44",
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ],
                 "family_bcf": [
                     [
@@ -1141,10 +1141,10 @@
                     "versions.yml:md5,77dbd5f16ae8b59d09563a07be6faa44",
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ]
             }
         ],
@@ -1152,7 +1152,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-12T18:16:05.823110437"
+        "timestamp": "2024-11-21T14:34:22.842191526"
     },
     "1 sample - no bed, fasta, fai, [], []": {
         "content": [
@@ -1211,10 +1211,10 @@
                     "versions.yml:md5,77dbd5f16ae8b59d09563a07be6faa44",
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ],
                 "family_bcf": [
                     [
@@ -1270,10 +1270,10 @@
                     "versions.yml:md5,77dbd5f16ae8b59d09563a07be6faa44",
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ]
             }
         ],
@@ -1281,7 +1281,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-12T18:12:47.703475448"
+        "timestamp": "2024-11-21T14:31:04.363638442"
     },
     "1 sample - 2 bed, fasta, fai, bed, []": {
         "content": [
@@ -1352,13 +1352,13 @@
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ],
                 "family_bcf": [
                     [
@@ -1426,13 +1426,13 @@
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ]
             }
         ],
@@ -1440,7 +1440,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-12T18:14:21.10363239"
+        "timestamp": "2024-11-21T14:32:38.48715039"
     },
     "2 samples - 2 bed, fasta, fai, bed, []": {
         "content": [
@@ -1534,8 +1534,6 @@
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
@@ -1543,7 +1541,9 @@
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ],
                 "family_bcf": [
                     [
@@ -1634,8 +1634,6 @@
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
@@ -1643,7 +1641,9 @@
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
                     "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ]
             }
         ],
@@ -1651,7 +1651,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-12T18:14:56.572901896"
+        "timestamp": "2024-11-21T14:33:13.404225198"
     },
     "1 sample - no bed, fasta, fai, [], [] - stub": {
         "content": [
@@ -1710,10 +1710,10 @@
                     "versions.yml:md5,77dbd5f16ae8b59d09563a07be6faa44",
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ],
                 "family_bcf": [
                     [
@@ -1769,10 +1769,10 @@
                     "versions.yml:md5,77dbd5f16ae8b59d09563a07be6faa44",
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ]
             }
         ],
@@ -1780,7 +1780,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-12T18:15:43.480727946"
+        "timestamp": "2024-11-21T14:33:59.832105156"
     },
     "1 sample - 1 bed, fasta, fai, [], [] - stub": {
         "content": [
@@ -1835,10 +1835,10 @@
                     "versions.yml:md5,77dbd5f16ae8b59d09563a07be6faa44",
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ],
                 "family_bcf": [
                     [
@@ -1890,10 +1890,10 @@
                     "versions.yml:md5,77dbd5f16ae8b59d09563a07be6faa44",
                     "versions.yml:md5,7d9ebdfc24f293b07e70dd2d18f44022",
                     "versions.yml:md5,afe349eb9156445b91cacdcfaabcf43d",
-                    "versions.yml:md5,b461c4ef2d44da4047b74239461bdff6",
                     "versions.yml:md5,dce103ef6b2f37c6844db8191418b9e6",
                     "versions.yml:md5,ee687c9b68546c8138fab17f68b967c0",
-                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531"
+                    "versions.yml:md5,f13ae32e1e3f3d274d4b3c7097f56531",
+                    "versions.yml:md5,f8e25357cdcef69ae5ee0cd801960b50"
                 ]
             }
         ],
@@ -1901,6 +1901,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-12T18:15:54.801886568"
+        "timestamp": "2024-11-21T14:34:11.123087909"
     }
 }

--- a/subworkflows/local/utils_nfcore_nallo_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_nallo_pipeline/main.nf
@@ -306,171 +306,6 @@ def genomeExistsError() {
 //
 // Generate methods description for MultiQC
 //
-def toolCitationText() {
-
-    def citation_text = [
-        "MultiQC (Ewels et al. 2016)",
-    ]
-    if (!params.skip_alignment) {
-        if (params.alignment_processes > 1) {
-            citation_text = citation_text + [
-                "splitubam",
-            ]
-        }
-        citation_text = citation_text + [
-            "SAMtools (Danecek et al. 2021)",
-            "Minimap2 (Li 2018)",
-            "Somalier (Pedersen et al. 2020)",
-            "Severus (Keskus et al. 2024)",
-            "Sniffles2 (Smolka et al. 2024)",
-            "SVDB (Eisfeldt et al. 2017)",
-        ]
-        if (!params.skip_qc) {
-            citation_text = citation_text + [
-                "FastQC (Andrews 2010)",
-                "cramino (De Coster & Rademakers 2023)",
-                "mosdepth (Pedersen & Quinlan 2018)",
-            ]
-        }
-        if (!params.skip_call_paralogs) {
-            citation_text = citation_text + [
-                "paraphase",
-            ]
-        }
-        if (!params.skip_genome_assembly) {
-            if (params.hifiasm_mode == 'trio-binning') {
-                citation_text = citation_text + [
-                    "yak",
-                ]
-            }
-            citation_text = citation_text + [
-                "Hifiasm (Cheng et al. 2021)",
-                "Gfastats (Formenti et al. 2022)",
-                "dipcall (Li et al. 2018)",
-                "SAMtools (Danecek et al. 2021)",
-                "Minimap2 (Li 2018)",
-            ]
-        }
-        if (!params.skip_snv_calling) {
-            citation_text = citation_text + [
-                "BEDTools (Quinlan & Hall 2010)",
-                "BCFtools (Danecek et al. 2021)",
-                "DeepVariant (Poplin et al. 2018)",
-                "GLnexus (Yun et al. 2021)",
-            ]
-        }
-        if (!params.skip_sv_annotation) {
-            citation_text = citation_text + [
-                "VEP (McLaren et al. 2016)",
-                "SVDB (Eisfeldt et al. 2017)",
-            ]
-        }
-        if (!params.skip_snv_annotation) {
-            citation_text = citation_text + [
-                "CADD (Rentzsch et al. 2019, Rentzsch et al. 2021)",
-                "BCFtools (Danecek et al. 2021)",
-                "VEP (McLaren et al. 2016)",
-                "Tabix (Li 2011)",
-                "Echtvar (Pedersen & de Ridder 2023)",
-            ]
-            if (!params.skip_rank_variants) {
-                citation_text = citation_text + [
-                    "Genmod (Magnusson et al. 2018)",
-                    "Tabix (Li 2011)",
-                ]
-            }
-        }
-        if (!params.skip_cnv_calling) {
-            citation_text = citation_text + [
-                "HiFiCNV",
-            ]
-        }
-        if (!params.skip_phasing) {
-            citation_text = citation_text + [
-                "SAMtools (Danecek et al. 2021)",
-                "cramino (De Coster & Rademakers 2023)",
-            ]
-            if(params.phaser == 'whatshap') {
-                citation_text = citation_text + [
-                    "WhatsHap (Martin et al. 2016)",
-                ]
-            }
-            if(params.phaser == 'hiphase') {
-                citation_text = citation_text + [
-                    "HiPhase (Holt et al. 2024)",
-                ]
-            }
-            if(params.phaser == 'longphase') {
-                citation_text = citation_text + [
-                    "LongPhase (Lin et al. 2024)",
-                ]
-            }
-            if (!params.skip_methylation_pileups) {
-                citation_text = citation_text + [
-                    "modkit",
-                    "Tabix (Li 2011)",
-                ]
-            }
-            if (!params.skip_repeat_calling) {
-                citation_text = citation_text + [
-                    "TRGT (Dolzhenko et al. 2024)",
-                ]
-                if (!params.skip_repeat_annotation) {
-                    citation_text = citation_text + [
-                        "Stranger (Nilsson & Magnusson 2021)",
-                    ]
-                }
-            }
-        }
-    }
-
-    def return_text = "Tools used in the workflow included: " + citation_text.unique(false) { a, b -> a <=> b }.join(', ') - "" + "."
-    return return_text
-}
-
-def toolBibliographyText() {
-
-    reference_text = [
-        "<li>Andrews S, (2010) FastQC, URL: https://www.bioinformatics.babraham.ac.uk/projects/fastqc/</li>",
-        "<li>Ewels PA, Peltzer A, Fillinger S, Patel H, Alneberg J, Wilm A, Garcia MU, Di Tommaso P, Nahnsen S. The nf-core framework for community-curated bioinformatics pipelines. Nat Biotechnol. 2020 Mar;38(3):276-278. doi: 10.1038/s41587-020-0439-x. PubMed PMID: 32055031.</li>",
-        "<li>Ewels P, Magnusson M, Lundin S, Käller M. MultiQC: summarize analysis results for multiple tools and samples in a single report. Bioinformatics. 2016 Oct 1;32(19):3047-8. doi: 10.1093/bioinformatics/btw354. Epub 2016 Jun 16. PubMed PMID: 27312411; PubMed Central PMCID: PMC5039924.</li>",
-        "<li>Di Tommaso P, Chatzou M, Floden EW, Barja PP, Palumbo E, Notredame C. Nextflow enables reproducible computational workflows. Nat Biotechnol. 2017 Apr 11;35(4):316-319. doi: 10.1038/nbt.3820. PubMed PMID: 28398311.</li>",
-        "<li>Danecek P, Bonfield JK, Liddle J, et al. Twelve years of SAMtools and BCFtools. GigaScience. 2021;10(2):giab008. doi:10.1093/gigascience/giab008</li>",
-        "<li>Quinlan AR and Hall IM, 2010. BEDTools: a flexible suite of utilities for comparing genomic features. Bioinformatics. 26, 6, pp. 841–842.</li>",
-        "<li>Wouter De Coster, Rosa Rademakers, NanoPack2: population-scale evaluation of long-read sequencing data, Bioinformatics, Volume 39, Issue 5, May 2023, btad311, https://doi.org/10.1093/bioinformatics/btad311</li>",
-        "<li>Rentzsch P, Schubach M, Shendure J, Kircher M. CADD-Splice—improving genome-wide variant effect prediction using deep learning-derived splice scores. Genome Med. 2021;13(1):31. doi:10.1186/s13073-021-00835-9</li>",
-        "<li>Rentzsch P, Witten D, Cooper GM, Shendure J, Kircher M. CADD: predicting the deleteriousness of variants throughout the human genome. Nucleic Acids Research. 2019;47(D1):D886-D894. doi:10.1093/nar/gky1016</li>",
-        "<li>Poplin R, Chang PC, Alexander D, et al. A universal SNP and small-indel variant caller using deep neural networks. Nat Biotechnol. 2018;36(10):983-987. doi:10.1038/nbt.4235</li>",
-        "<li>Li H, Bloom JM, Farjoun Y, Fleharty M, Gauthier L, Neale B, MacArthur D (2018) A synthetic-diploid benchmark for accurate variant-calling evaluation. Nat Methods, 15:595-597. [PMID:30013044]</li>",
-        "<li>Brent S Pedersen, Jeroen de Ridder, Echtvar: compressed variant representation for rapid annotation and filtering of SNPs and indels, Nucleic Acids Research, Volume 51, Issue 1, 11 January 2023, Page e3, https://doi.org/10.1093/nar/gkac931</li>",
-        "<li>McLaren W, Gil L, Hunt SE, et al. The Ensembl Variant Effect Predictor. Genome Biol. 2016;17(1):122. doi:10.1186/s13059-016-0974-4</li>",
-        "<li>Andrews, S. (2010). FastQC: A Quality Control Tool for High Throughput Sequence Data [Online].</li>",
-        "<li>Magnusson M, Hughes T, Glabilloy, Bitdeli Chef. genmod: Version 3.7.3. Published online November 15, 2018. doi:10.5281/ZENODO.3841142</li>",
-        "<li>Giulio Formenti, Linelle Abueg, Angelo Brajuka, Nadolina Brajuka, Cristóbal Gallardo-Alba, Alice Giani, Olivier Fedrigo, Erich D Jarvis, Gfastats: conversion, evaluation and manipulation of genome sequences using assembly graphs, Bioinformatics, Volume 38, Issue 17, September 2022, Pages 4214–4216, https://doi.org/10.1093/bioinformatics/btac460</li>",
-        "<li>Yun T, Li H, Chang PC, Lin MF, Carroll A, McLean CY. Accurate, scalable cohort variant calls using DeepVariant and GLnexus. Robinson P, ed. Bioinformatics. 2021;36(24):5582-5589. doi:10.1093/bioinformatics/btaa1081</li>",
-        "<li>Cheng, H., Concepcion, G.T., Feng, X. et al. Haplotype-resolved de novo assembly using phased assembly graphs with hifiasm. Nat Methods 18, 170–175 (2021). https://doi.org/10.1038/s41592-020-01056-5</li>",
-        "<li>James M Holt, Christopher T Saunders, William J Rowell, Zev Kronenberg, Aaron M Wenger, Michael Eberle, HiPhase: jointly phasing small, structural, and tandem repeat variants from HiFi sequencing, Bioinformatics, Volume 40, Issue 2, February 2024, btae042, https://doi.org/10.1093/bioinformatics/btae042</li>",
-        "<li>Jyun-Hong Lin, Liang-Chi Chen, Shu-Chi Yu, Yao-Ting Huang, LongPhase: an ultra-fast chromosome-scale phasing algorithm for small and large variants, Bioinformatics, Volume 38, Issue 7, March 2022, Pages 1816–1822, https://doi.org/10.1093/bioinformatics/btac058</li>",
-        "<li>Heng Li, Minimap2: pairwise alignment for nucleotide sequences, Bioinformatics, Volume 34, Issue 18, September 2018, Pages 3094–3100, https://doi.org/10.1093/bioinformatics/bty191</li>",
-        "<li>Pedersen BS, Quinlan AR. Mosdepth: quick coverage calculation for genomes and exomes. Hancock J, ed. Bioinformatics. 2018;34(5):867-868. doi:10.1093/bioinformatics/btx699</li>",
-        "<li>Genome-wide profiling of highly similar paralogous genes using HiFi sequencing. Xiao Chen, Daniel Baker, Egor Dolzhenko, Joseph M Devaney, Jessica Noya, April S Berlyoung, Rhonda Brandon, Kathleen S Hruska, Lucas Lochovsky, Paul Kruszka, Scott Newman, Emily Farrow, Isabelle Thiffault, Tomi Pastinen, Dalia Kasperaviciute, Christian Gilissen, Lisenka Vissers, Alexander Hoischen, Seth Berger, Eric Vilain, Emmanuèle Délot, UCI Genomics Research to Elucidate the Genetics of Rare Diseases (UCI GREGoR) Consortium, Michael A Eberle. bioRxiv 2024.04.19.590294; doi: https://doi.org/10.1101/2024.04.19.590294</li>",
-        "<li>Ayse Keskus, Asher Bryant, Tanveer Ahmad, Byunggil Yoo, Sergey Aganezov, Anton Goretsky, Ataberk Donmez, Lisa A. Lansdon, Isabel Rodriguez, Jimin Park, Yuelin Liu, Xiwen Cui, Joshua Gardner, Brandy McNulty, Samuel Sacco, Jyoti Shetty, Yongmei Zhao, Bao Tran, Giuseppe Narzisi, Adrienne Helland, Daniel E. Cook, Pi-Chuan Chang, Alexey Kolesnikov, Andrew Carroll, Erin K. Molloy, Irina Pushel, Erin Guest, Tomi Pastinen, Kishwar Shafin, Karen H. Miga, Salem Malikic, Chi-Ping Day, Nicolas Robine, Cenk Sahinalp, Michael Dean, Midhat S. Farooqi, Benedict Paten, Mikhail Kolmogorov. Severus: accurate detection and characterization of somatic structural variation in tumor genomes using long reads. medRxiv 2024.03.22.24304756; doi: https://doi.org/10.1101/2024.03.22.24304756",
-        "<li>Smolka, M., Paulin, L.F., Grochowski, C.M. et al. Detection of mosaic and population-level structural variants with Sniffles2. Nat Biotechnol (2024). https://doi.org/10.1038/s41587-023-02024-y</li>",
-        "<li>Pedersen, B.S., Bhetariya, P.J., Brown, J. et al. Somalier: rapid relatedness estimation for cancer and germline studies using efficient genome sketches. Genome Med 12, 62 (2020). https://doi.org/10.1186/s13073-020-00761-2</li>",
-        "<li>Nilsson D, Magnusson M. moonso/stranger v0.7.1. Published online February 18, 2021. doi:10.5281/ZENODO.4548873</li>",
-        "<li>Li H. Tabix: fast retrieval of sequence features from generic TAB-delimited files. Bioinformatics. 2011;27(5):718-719. doi:10.1093/bioinformatics/btq671</li>",
-        "<li>Dolzhenko, E., English, A., Dashnow, H. et al. Characterization and visualization of tandem repeats at genome scale. Nat Biotechnol (2024). https://doi.org/10.1038/s41587-023-02057-3</li>",
-        "<li>Marcel Martin, Murray Patterson, Shilpa Garg, Sarah O Fischer, Nadia Pisanti, Gunnar W Klau, Alexander Schöenhuth, Tobias Marschall. bioRxiv 085050; doi: https://doi.org/10.1101/085050</li>",
-        "<li>Anaconda Software Distribution. Computer software. Vers. 2-2.4.0. Anaconda, Nov. 2016. Web.</li>",
-        "<li>Grüning B, Dale R, Sjödin A, Chapman BA, Rowe J, Tomkins-Tinch CH, Valieris R, Köster J; Bioconda Team. Bioconda: sustainable and comprehensive software distribution for the life sciences. Nat Methods. 2018 Jul;15(7):475-476. doi: 10.1038/s41592-018-0046-7. PubMed PMID: 29967506.</li>",
-        "<li>da Veiga Leprevost F, Grüning B, Aflitos SA, Röst HL, Uszkoreit J, Barsnes H, Vaudel M, Moreno P, Gatto L, Weber J, Bai M, Jimenez RC, Sachsenberg T, Pfeuffer J, Alvarez RV, Griss J, Nesvizhskii AI, Perez-Riverol Y. BioContainers: an open-source and community-driven framework for software standardization. Bioinformatics. 2017 Aug 15;33(16):2580-2582. doi: 10.1093/bioinformatics/btx192. PubMed PMID: 28379341; PubMed Central PMCID: PMC5870671.</li>",
-        "<li>Merkel, D. (2014). Docker: lightweight linux containers for consistent development and deployment. Linux Journal, 2014(239), 2. doi: 10.5555/2600239.2600241.</li>",
-        "<li>Kurtzer GM, Sochat V, Bauer MW. Singularity: Scientific containers for mobility of compute. PLoS One. 2017 May 11;12(5):e0177459. doi: 10.1371/journal.pone.0177459. eCollection 2017. PubMed PMID: 28494014; PubMed Central PMCID: PMC5426675.</li>",
-    ].join(' ').trim()
-
-    return reference_text
-}
-
 def methodsDescriptionText(mqc_methods_yaml) {
     // Convert  to a named map so can be used as with familar NXF ${workflow} variable syntax in the MultiQC YML file
     def meta = [:]
@@ -491,19 +326,58 @@ def methodsDescriptionText(mqc_methods_yaml) {
     } else meta["doi_text"] = ""
     meta["nodoi_text"] = meta.manifest_map.doi ? "" : "<li>If available, make sure to update the text to include the Zenodo DOI of version of the pipeline used. </li>"
 
-    // Tool references
-    meta["tool_citations"] = ""
-    meta["tool_bibliography"] = ""
-
-    meta["tool_citations"] = toolCitationText().replaceAll(", \\.", ".").replaceAll("\\. \\.", ".").replaceAll(", \\.", ".")
-    meta["tool_bibliography"] = toolBibliographyText()
-
     def methods_text = mqc_methods_yaml.text
 
     def engine =  new groovy.text.SimpleTemplateEngine()
     def description_html = engine.createTemplate(methods_text).make(meta)
 
     return description_html.toString()
+}
+
+def extractSoftwareFromVersions(module_yaml_file) {
+    def yaml = new org.yaml.snakeyaml.Yaml()
+    def yamlData = yaml.load(module_yaml_file)
+    // Extract all software (keys) from a module yaml
+    def softwareInModule = yamlData.values().collect { it.keySet() }.flatten()
+    return softwareInModule
+}
+
+def generateReferenceHTML(tool_list, description) {
+    def items = tool_list
+        .collect { it.trim() }
+        .unique()              // samtools and bcftools share reference
+        .findAll { it != "" }  // some tools does not have a reference, e.g. awk, gunzip
+
+    if (description == 'citation') {
+        return "  <p>Tools used in the workflow included: ${items.join(', ')}.</p>"
+    } else if (description == 'bibliography') {
+        return "  <h4>References</h4><ul><li>${items.join('</li><li>')}</li></ul>"
+    }
+}
+
+def citationBibliographyText(ch_versions, references_yaml, description) {
+    def yaml = new org.yaml.snakeyaml.Yaml()
+    def softwareReferences = yaml.load(references_yaml.text).tool
+
+    def unwantedReferences = ['genomic-medicine-sweden/nallo', 'Nextflow']
+    // These are not collected in ch_versions but should be referenced
+    baseTools = Channel.from(['nextflow', 'nf_core', 'bioconda', 'biocontainers', 'multiqc'])
+
+    ch_versions
+        .map { module_yaml -> extractSoftwareFromVersions(module_yaml) }
+        .flatten() // split multi-tool modules
+        .unique()
+        .filter { tool -> !unwantedReferences.contains(tool) }
+        .concat(baseTools)
+        .collect { tool ->
+            def toolDetails = softwareReferences[tool]
+            if (toolDetails == null) {
+                throw new IllegalStateException("Tool: '${tool}' not found in ${references_yaml}")
+            }
+            return toolDetails[description]
+        }
+        .sort()
+        .map { tools -> generateReferenceHTML(tools, description) }
 }
 
 //

--- a/tests/samplesheet.nf.test.snap
+++ b/tests/samplesheet.nf.test.snap
@@ -5,7 +5,7 @@
             {
                 "ADD_FOUND_IN_TAG": {
                     "bcftools": 1.2,
-                    "busybox-awk": "1.36.1"
+                    "busybox_awk": "1.36.1"
                 },
                 "ADD_MOST_SEVERE_CSQ": {
                     "add_most_severe_consequence": 1.0,
@@ -674,6 +674,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-18T08:53:15.024737825"
+        "timestamp": "2024-11-21T14:03:21.656937036"
     }
 }

--- a/tests/samplesheet_multisample_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_bam.nf.test.snap
@@ -5,7 +5,7 @@
             {
                 "ADD_FOUND_IN_TAG": {
                     "bcftools": 1.2,
-                    "busybox-awk": "1.36.1"
+                    "busybox_awk": "1.36.1"
                 },
                 "ADD_MOST_SEVERE_CSQ": {
                     "add_most_severe_consequence": 1.0,
@@ -874,6 +874,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-18T08:55:12.484845801"
+        "timestamp": "2024-11-21T14:05:18.173305906"
     }
 }

--- a/tests/samplesheet_multisample_ont_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_ont_bam.nf.test.snap
@@ -5,7 +5,7 @@
             {
                 "ADD_FOUND_IN_TAG": {
                     "bcftools": 1.2,
-                    "busybox-awk": "1.36.1"
+                    "busybox_awk": "1.36.1"
                 },
                 "ADD_MOST_SEVERE_CSQ": {
                     "add_most_severe_consequence": 1.0,
@@ -643,6 +643,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-11-18T08:57:05.873919937"
+        "timestamp": "2024-11-21T14:14:54.739862156"
     }
 }


### PR DESCRIPTION
This PR adds a `software_references.yml` and uses that together with the tools reported in `ch_versions` to dynamically write the methods description tools and references, depending on how subworkflows are skipped and params set.

This should make the method description easier to maintain when adding or moving around tools and subworkflows. An error will also be produced if a new tool is added without an entry in `software_references.yml`.

<img width="1147" alt="Screenshot 2024-11-21 at 14 02 54" src="https://github.com/user-attachments/assets/4fb993c8-19cc-4e61-992f-e0f5a4334b1b">


Closes #508.

<!--
# genomic-medicine-sweden/nallo pull re

quest

Many thanks for contributing to genomic-medicine-sweden/nallo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
