### PR TITLE
Fix sniffles1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#566](https://github.com/genomic-medicine-sweden/nallo/pull/566) - Fixed wrong minimap2 mapping preset for genome assemblies
 - [#570](https://github.com/genomic-medicine-sweden/nallo/pull/570) - Fixed bug where filtering of SNVs was trying to run even if `--skip_snv_calling` was active
 - [#578](https://github.com/genomic-medicine-sweden/nallo/pull/578) - Fixed warning about non-existing `params.genome` when running the pipeline
+- [#580](https://github.com/genomic-medicine-sweden/nallo/pull/580) - Fixed missing nf-test triggers for changes that may affect the entire pipeline
 
 ### Parameters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#566](https://github.com/genomic-medicine-sweden/nallo/pull/566) - Replaced dipcall with `ALIGN_ASSEMBLIES`, mostly mimicing the alignment part of dipcall, while omitting the variant calling. Updated docs and output files.
 - [#572](https://github.com/genomic-medicine-sweden/nallo/pull/572) - Changed `CALL_SVS` to sort sniffles1 variants, which could be unsorted by default
 - [#573](https://github.com/genomic-medicine-sweden/nallo/pull/573) - Updated metro-map to reflect changes to sniffles and dipcall
+- [#580](https://github.com/genomic-medicine-sweden/nallo/pull/580) - Changed `CLEAN_SNIFFLES` to fix sniffles1 header and DUP/INV end position 
 
 ### `Removed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#566](https://github.com/genomic-medicine-sweden/nallo/pull/566) - Replaced dipcall with `ALIGN_ASSEMBLIES`, mostly mimicing the alignment part of dipcall, while omitting the variant calling. Updated docs and output files.
 - [#572](https://github.com/genomic-medicine-sweden/nallo/pull/572) - Changed `CALL_SVS` to sort sniffles1 variants, which could be unsorted by default
 - [#573](https://github.com/genomic-medicine-sweden/nallo/pull/573) - Updated metro-map to reflect changes to sniffles and dipcall
-- [#580](https://github.com/genomic-medicine-sweden/nallo/pull/580) - Changed `CLEAN_SNIFFLES` to fix sniffles1 header and DUP/INV end position 
+- [#580](https://github.com/genomic-medicine-sweden/nallo/pull/580) - Changed `CLEAN_SNIFFLES` to fix sniffles1 header and DUP/INV end position
 
 ### `Removed`
 

--- a/bin/clean_sniffles.py
+++ b/bin/clean_sniffles.py
@@ -22,5 +22,5 @@ for line in open(sys.argv[1]):
         before=var[0]
         after=var[-1]
         line=before+after
- 
+
     print(line.strip())

--- a/bin/clean_sniffles.py
+++ b/bin/clean_sniffles.py
@@ -1,26 +1,26 @@
 #!/usr/bin/env python3
 
-# https://raw.githubusercontent.com/J35P312/poorpipe/cd0ccd0638a0b182d62d9d75b3237b6087ebcce0/poorpipe/utils/clean_sniffles.py
+# modified from https://raw.githubusercontent.com/J35P312/poorpipe/cd0ccd0638a0b182d62d9d75b3237b6087ebcce0/poorpipe/utils/clean_sniffles.py
 
 import sys
 
 for line in open(sys.argv[1]):
-	if line[0] == "#":
-		print(line.strip())
-		continue
+    if line[0] == "#":
+        if line.startswith('##FILTER'):
+            print('##FILTER=<ID=STRANDBIAS,Description="Not sure what this means">')
+        print(line.strip())
+        continue
 
-	if "SVTYPE=INS" in line or "SVTYPE=BND" in line or "SVTYPE:DUP/INS" in line:
-		var=line.strip().split(";END=")
-		before=var[0]
-		after=var[-1].lstrip("0123456789")
-		line=before+after
+    if "SVTYPE=INS" in line or "SVTYPE=BND" in line or "SVTYPE=DUP/INS" in line:
+        var=line.strip().split(";END=")
+        before=var[0]
+        after=var[-1].lstrip("0123456789")
+        line=before+after
 
-	if "SVTYPE=BND" in line:
-		var=line.strip().split(";SVLEN=1")
-		before=var[0]
-		after=var[-1]
-		line=before+after
-
-
-
-	print(line.strip())
+    if "SVTYPE=BND" in line:
+        var=line.strip().split(";SVLEN=1")
+        before=var[0]
+        after=var[-1]
+        line=before+after
+ 
+    print(line.strip())

--- a/nf-test.config
+++ b/nf-test.config
@@ -7,6 +7,8 @@ config {
     configFile "conf/test.config"
     // run all test with defined profile(s) from the main nextflow.config
     profile "test"
+    triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'conf/test_full.config', 'bin/'
+
     // Include plugins
     plugins {
         load "nft-bam@0.4.0"

--- a/subworkflows/local/call_svs/tests/main.nf.test.snap
+++ b/subworkflows/local/call_svs/tests/main.nf.test.snap
@@ -517,6 +517,7 @@
                 "##contig=<ID=chrUn_GL000216v2,length=176608>",
                 "##contig=<ID=chrUn_GL000218v1,length=161147>",
                 "##contig=<ID=chrEBV,length=171823>",
+                "##FILTER=<ID=STRANDBIAS,Description=\"Not sure what this means\">",
                 "##FILTER=<ID=UNRESOLVED,Description=\"An insertion that is longer than the read and thus we cannot predict the full size.\">",
                 "##FORMAT=<ID=DR,Number=1,Type=Integer,Description=\"# high-quality reference reads\">",
                 "##FORMAT=<ID=DV,Number=1,Type=Integer,Description=\"# high-quality variant reads\">",
@@ -612,7 +613,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.10.3"
         },
-        "timestamp": "2025-02-25T09:20:10.640467285"
+        "timestamp": "2025-02-26T18:58:30.977090278"
     },
     "2 samples - [bam, bai], 'severus', []": {
         "content": [


### PR DESCRIPTION
Closes #579, and fixes another bug in the clean_sniffles.py script where `SVTYPE:DUP/INS` should be `SVTYPE=DUP/INS`.

I also realised that some nf-test triggers were missing, e.g. if you modify `nextflow.config` then all tests should be run. I also added the bin directory to that list.

<!--
# genomic-medicine-sweden/nallo pull request

Closes #579

Many thanks for contributing to genomic-medicine-sweden/nallo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
