### PR TITLE
Skip unneccessary CRAM conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#723](https://github.com/genomic-medicine-sweden/nallo/pull/723) - Refactored SV-calling for more flexiblity when choosing callers
 - [#723](https://github.com/genomic-medicine-sweden/nallo/pull/723) - Changed default SV-caller from Severus to Sniffles and HiFiCNV
 - [#724](https://github.com/genomic-medicine-sweden/nallo/pull/724) - Changed the inputs for the FASTQ conversion for the assembly subworkflow to use split BAM files instead of input BAM files when suitable
+- [#728](https://github.com/genomic-medicine-sweden/nallo/pull/728) - Changed to only run CRAM conversion for unphased reads when not phasing reads, since they not output when phasing
 
 ### `Removed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#723](https://github.com/genomic-medicine-sweden/nallo/pull/723) - Changed default SV-caller from Severus to Sniffles and HiFiCNV
 - [#724](https://github.com/genomic-medicine-sweden/nallo/pull/724) - Changed the inputs for the FASTQ conversion for the assembly subworkflow to use split BAM files instead of input BAM files when suitable
 - [#726](https://github.com/genomic-medicine-sweden/nallo/pull/726) - Changed cram output test from `samplesheet_multisample_bam` to `samplesheet_target_regions_null` (run on PR towards master), because of slow nf-test
-- [#728](https://github.com/genomic-medicine-sweden/nallo/pull/728) - Changed to only run CRAM conversion for unphased reads when not phasing reads, since they not output when phasing
+- [#728](https://github.com/genomic-medicine-sweden/nallo/pull/728) - Changed to only run CRAM conversion for unphased reads when not phasing reads, since they are not published when phasing
 
 ### `Removed`
 

--- a/conf/modules/nallo.config
+++ b/conf/modules/nallo.config
@@ -175,7 +175,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/aligned_reads/${meta.id}" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') || !params.skip_phasing ? null : filename }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 

--- a/subworkflows/local/phasing/main.nf
+++ b/subworkflows/local/phasing/main.nf
@@ -18,7 +18,7 @@ workflow PHASING {
     ch_bam_bai   // channel: [ val(meta), path(bam), path(bai) ]
     fasta        // channel: [ val(meta), path(fasta) ]
     fai          // channel: [ val(meta), path(fai) ]
-    cram_output   // bool: Publish alignments as CRAM (true) or BAM (false)
+    cram_output  //    bool: Publish alignments as CRAM (true) or BAM (false)
 
     main:
     ch_versions            = Channel.empty()

--- a/tests/samplesheet_multisample_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_bam.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "samplesheet_multisample_bam | --filter_variants_hgnc_ids null --phaser hiphase --alignment_output_format cram": {
         "content": [
-            266,
+            263,
             {
                 "ADD_FOUND_IN_TAG": {
                     "bcftools": 1.2,
@@ -880,6 +880,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.6"
         },
-        "timestamp": "2025-07-14T11:20:56.898142102"
+        "timestamp": "2025-07-15T11:22:32.331858093"
     }
 }

--- a/workflows/nallo.nf
+++ b/workflows/nallo.nf
@@ -257,7 +257,7 @@ workflow NALLO {
             .set { ch_aligned_bam }
 
         // Publish alignments as CRAM if requested
-        if (cram_output) {
+        if (cram_output && params.skip_phasing) {
             SAMTOOLS_CONVERT (
                 ch_aligned_bam,
                 ch_fasta,


### PR DESCRIPTION
This PR changes to only run CRAM conversion for unphased reads when not phasing reads. Since unphased reads are not output when phasing (instead the phased reads are converted and output), running this process is unnecessary.

<!--
# genomic-medicine-sweden/nallo pull request

Many thanks for contributing to genomic-medicine-sweden/nallo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
