### PR TITLE
Convert `ext.args` with parameters to closures so parameters are evaluated at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#855](https://github.com/genomic-medicine-sweden/nallo/pull/855) - Updated nf-core modules
 - [#920](https://github.com/genomic-medicine-sweden/nallo/pull/920) - Updated version to 0.12.0dev
 - [#933](https://github.com/genomic-medicine-sweden/nallo/pull/933) - Changed tags of variant ranking processes to include analysis set
+- [#940](https://github.com/genomic-medicine-sweden/nallo/pull/940) - Changed ext.args with parameters introduced in [#934](https://github.com/genomic-medicine-sweden/nallo/pull/934) to closures so parameters are evaluated at runtime
 
 ### Removed
 

--- a/conf/modules/call_svs.config
+++ b/conf/modules/call_svs.config
@@ -69,10 +69,10 @@ process {
 
     withName: '.*:CALL_SVS:SAWFISH_DISCOVER' {
         ext.prefix = { "${meta.id}_sawfish_discover" }
-        ext.args = [
+        ext.args = { [
             "${params.extra_sawfish_options}",
             "--min-indel-size ${params.sawfish_min_sv_size}"
-        ].join(' ')
+        ].join(' ') }
     }
 
     withName: '.*:CALL_SVS:SAWFISH_JOINTCALL' {
@@ -94,7 +94,7 @@ process {
 
     withName: '.*:CALL_SVS:SNIFFLES' {
         ext.prefix = { "${meta.id}_sniffles_for_reheader" }
-        ext.args = [
+        ext.args = { [
             '--cluster',
             '--genotype',
             '--ignore_sd',
@@ -103,7 +103,7 @@ process {
             "--min_seq_size ${params.sniffles_min_segment_length}",
             "--min_length ${params.sniffles_min_sv_size}",
             "--min_het_af ${params.sniffles_min_heterozygous_allele_frequency}"
-        ].join(' ')
+        ].join(' ') }
     }
 
     withName: '.*:CALL_SVS:SVDB_MERGE_BY_CALLER' {

--- a/conf/modules/gvcf_glnexus_norm_variants.config
+++ b/conf/modules/gvcf_glnexus_norm_variants.config
@@ -32,7 +32,7 @@ process {
     }
 
     withName: '.*:GVCF_GLNEXUS_NORM_VARIANTS:BCFTOOLS_PLUGINFIXPLOIDY' {
-        ext.prefix = {  "${meta.id}_ploidyfix" }
+        ext.prefix = { "${meta.id}_ploidyfix" }
         ext.args = [
             '--output-type z',
             '--write-index=tbi',

--- a/conf/modules/longphase.config
+++ b/conf/modules/longphase.config
@@ -21,10 +21,10 @@ process {
 
     withName: '.*:LONGPHASE:LONGPHASE_PHASE' {
         ext.prefix = { "${meta.id}_longphase" }
-        ext.args = [
+        ext.args = { [
             params.preset.equals('ONT_R10') ? "--ont" : "--pb",
             '--indels'
-        ].join(' ')
+        ].join(' ') }
     }
 
     withName: '.*:LONGPHASE:LONGPHASE_HAPLOTAG' {

--- a/conf/modules/vcf_concat_sort_variants.config
+++ b/conf/modules/vcf_concat_sort_variants.config
@@ -51,7 +51,7 @@ process {
             }
             return name.join('_')
         }
-        ext.args   = {
+        ext.args = {
             [
                 '--output-type z',
                 '--write-index=tbi',

--- a/nf-test.config
+++ b/nf-test.config
@@ -13,7 +13,7 @@ config {
 
     // run all test with defined profile(s) from the main nextflow.config
     profile "test"
-    triggers 'nextflow.config', 'nf-test.config', 'conf/', 'tests/nextflow.config', 'tests/.nftignore', 'bin/', 'assets/samplesheet*', 'assets/echtvar_snv_databases.csv'
+    triggers 'nextflow.config', 'nf-test.config', 'conf/*', 'tests/nextflow.config', 'tests/.nftignore', 'bin/*', 'assets/samplesheet*', 'assets/echtvar_snv_databases.csv'
 
     // Include plugins
     plugins {


### PR DESCRIPTION
Convert ext.args with parameters to closures so parameters are evaluated at runtime. This ensures profile-specific parameters (i.e. the `test` profile) are correctly applied. 

Otherwise, it has to be explicitly stated, e.g. with `nf-test test --profile test, docker` or `nf-test test --profiler +docker`. Just `nf-test test --profile docker` won't work without closures.

<!--
# genomic-medicine-sweden/nallo pull request

Many thanks for contributing to genomic-medicine-sweden/nallo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
