### PR TITLE
Add `igenomes` and `fastqc` to template skip features

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -43,5 +43,7 @@ template:
   name: nallo
   org: genomic-medicine-sweden
   outdir: .
-  skip_features: []
+  skip_features:
+    - igenomes
+    - fastqc
   version: 0.12.0dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#957](https://github.com/genomic-medicine-sweden/nallo/pull/957) - Added new `--skip_sex_check` parameter and validation for its usage in the pipeline
 - [#959](https://github.com/genomic-medicine-sweden/nallo/pull/959) - Added GitHub workflow to add the PR checklist as a comment
 - [#960](https://github.com/genomic-medicine-sweden/nallo/pull/960) - Added stub test for Chromograph with skipped annotation
+- [#971](https://github.com/genomic-medicine-sweden/nallo/pull/971) - Added `igenomes` and `fastqc` to template skip features, making future template updates smoother
 
 ### Changed
 


### PR DESCRIPTION
## Description

This will make future template updates smoother, since the template will not include items we do not use in Nallo.

### Added

- Added `igenomes` and `fastqc` to template skip features.