### PR TITLE
Module upgrade: nf-core/stranger to 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1019](https://github.com/genomic-medicine-sweden/nallo/pull/1019) - Update nf-schema to 2.7.0
 - [#1020](https://github.com/genomic-medicine-sweden/nallo/pull/1020) - Updated `utils_nfschema_plugin`
 - [#1021](https://github.com/genomic-medicine-sweden/nallo/pull/1021) - Updated parameters documentation
+- [#1034](https://github.com/genomic-medicine-sweden/nallo/pull/1034) - Update stranger to 0.10.2
 
 ### Removed
 
@@ -130,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | samtools/view                   | 1.22.1      |  1.23.1     |
 | severus                         | 1.6         |  1.7        |
 | strdrust                        | 0.11.4      |  0.16.0     |
+| stranger                        | 0.10.0      |  0.10.2     |
 
 > [!NOTE]
 > Version has been updated if both old and new version information is present.

--- a/modules.json
+++ b/modules.json
@@ -374,7 +374,7 @@
                     },
                     "stranger": {
                         "branch": "master",
-                        "git_sha": "f2b138ee1d91f67d31c187317d7e83e429bf0309",
+                        "git_sha": "90e0aedba7e6b6cd6a0a7edc612c3f54f0caa663",
                         "installed_by": ["modules"]
                     },
                     "strdrop/call": {

--- a/modules/nf-core/stranger/environment.yml
+++ b/modules/nf-core/stranger/environment.yml
@@ -4,8 +4,8 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::htslib=1.23
-  - conda-forge::pip=25.3
-  - conda-forge::python=3.14.2
+  - bioconda::htslib=1.23.1
+  - conda-forge::python=3.14.4
+  - conda-forge::pip=26.0.1
   - pip:
-      - stranger==0.10.0
+      - stranger==0.10.2

--- a/modules/nf-core/stranger/main.nf
+++ b/modules/nf-core/stranger/main.nf
@@ -3,9 +3,9 @@ process STRANGER {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/90/90f7f35b37e9e31c8680c18ef59c76e74500f44664887b3c1131daf07ff3043f/data':
-        'community.wave.seqera.io/library/htslib_pip_stranger:de13e0cf88d77b50' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/96/969730adce57ebf531cffc0c4ac4dfdbfc52dea11290477afa58428193adb796/data':
+        'community.wave.seqera.io/library/htslib_pip_python_stranger:beca035d9e9d6787' }"
 
     input:
     tuple val(meta), path(vcf)

--- a/modules/nf-core/stranger/tests/main.nf.test.snap
+++ b/modules/nf-core/stranger/tests/main.nf.test.snap
@@ -22,14 +22,14 @@
                     [
                         "STRANGER",
                         "stranger",
-                        "0.10.0"
+                        "0.10.2"
                     ]
                 ],
                 "3": [
                     [
                         "STRANGER",
                         "tabix",
-                        "1.23"
+                        "1.23.1"
                     ]
                 ],
                 "tbi": [
@@ -52,23 +52,23 @@
                     [
                         "STRANGER",
                         "stranger",
-                        "0.10.0"
+                        "0.10.2"
                     ]
                 ],
                 "versions_tabix": [
                     [
                         "STRANGER",
                         "tabix",
-                        "1.23"
+                        "1.23.1"
                     ]
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-01-30T15:59:31.211437829"
+        "timestamp": "2026-04-23T14:27:33.511593306"
     },
     "homo_sapiens - vcf, repeat_catalogue": {
         "content": [
@@ -78,7 +78,7 @@
                         {
                             "id": "test"
                         },
-                        "stranger.vcf.gz:md5,5c55cbc7404f2d03b8cac82733175783"
+                        "stranger.vcf.gz:md5,7bccff6da8e34606dccad76c44434e76"
                     ]
                 ],
                 "1": [
@@ -86,21 +86,21 @@
                         {
                             "id": "test"
                         },
-                        "stranger.vcf.gz.tbi:md5,9ac34e9ea9d9e3eee971b542629259c3"
+                        "stranger.vcf.gz.tbi:md5,587822ec191e1840e306146b7e5dafcd"
                     ]
                 ],
                 "2": [
                     [
                         "STRANGER",
                         "stranger",
-                        "0.10.0"
+                        "0.10.2"
                     ]
                 ],
                 "3": [
                     [
                         "STRANGER",
                         "tabix",
-                        "1.23"
+                        "1.23.1"
                     ]
                 ],
                 "tbi": [
@@ -108,7 +108,7 @@
                         {
                             "id": "test"
                         },
-                        "stranger.vcf.gz.tbi:md5,9ac34e9ea9d9e3eee971b542629259c3"
+                        "stranger.vcf.gz.tbi:md5,587822ec191e1840e306146b7e5dafcd"
                     ]
                 ],
                 "vcf": [
@@ -116,29 +116,29 @@
                         {
                             "id": "test"
                         },
-                        "stranger.vcf.gz:md5,5c55cbc7404f2d03b8cac82733175783"
+                        "stranger.vcf.gz:md5,7bccff6da8e34606dccad76c44434e76"
                     ]
                 ],
                 "versions_stranger": [
                     [
                         "STRANGER",
                         "stranger",
-                        "0.10.0"
+                        "0.10.2"
                     ]
                 ],
                 "versions_tabix": [
                     [
                         "STRANGER",
                         "tabix",
-                        "1.23"
+                        "1.23.1"
                     ]
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-01-30T15:59:14.37967244"
+        "timestamp": "2026-04-23T14:27:21.359555969"
     }
 }


### PR DESCRIPTION
## Description

Fixes issue with malformed GT fields when decomposing variants with REF calls 

### Changed
- Update nf-core/stranger to 0.10.2

