### PR TITLE
Fix nf-test CI not passing the matrix Nextflow version to the setup action.

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -109,6 +109,7 @@ jobs:
         uses: ./.github/actions/nf-test
         env:
           NFT_WORKDIR: ${{ env.NFT_WORKDIR }}
+          NXF_VERSION: ${{ matrix.NXF_VER }}
         with:
           profile: ${{ matrix.profile }}
           tags: ${{ matrix.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#1056](https://github.com/genomic-medicine-sweden/nallo/pull/1056) - Fixed nf-test CI not passing the matrix Nextflow version to the setup action.
+
 ### Parameters
 
 | Old parameter | New parameter |


### PR DESCRIPTION
## Description

fixes #1055 . 

The versions specified in the CI nextflow version matrix are not passed to the nf-test CI setup, which leads to 25.10.0 currently resolving to the latest available version of nextflow.

This patch fixes the behavior so that the tests with specified version run under the correct version of nextflow

### Added

-

### Changed

-

### Fixed

- NXF version env var not passed to nf-test setup, leading to CI always defaulting to the latest version of Nextflow

### Removed

-
