### PR TITLE
Update contribution guidelines regarding `.set` which might soon be restricted

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -238,8 +238,7 @@ We are currently migrating from using `publishDir` to workflow outputs.
   publish = ch_publish  // channel: [ val(destination), val(value) ]
   ```
 
-- Avoid using `ch_* = <...>`, use the `.set {ch_*}` operator to create new channels whenever possible.
-
+- Use `ch_* = <...>` to declare a new channel, using `.set` will [soon be restricted](https://docs.seqera.io/nextflow/workflow-typed#restricted-syntax).
 - Use the nextflow code formatting (`nextflow lint -harshil-alignment -format file.nf`) after making changes, but beware that it currently removes some inline comments.
 - Use comment-blocks for multi-line comments, e.g.:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1050](https://github.com/genomic-medicine-sweden/nallo/pull/1050) - Changed version to 0.13.0dev
 - [#1058](https://github.com/genomic-medicine-sweden/nallo/pull/1058) - Update nf-test in CI to 0.9.5
 - [#1061](https://github.com/genomic-medicine-sweden/nallo/pull/1061) - Changed `annotated_repeats` workflow outputs to not include params.outdir, added by mistake in [#1041](https://github.com/genomic-medicine-sweden/nallo/pull/1041)
+- [#1062](https://github.com/genomic-medicine-sweden/nallo/pull/1062) - Updated contribution guidelines regarding `.set` which might soon be restricted
 
 ### Removed
 


### PR DESCRIPTION
## Description

`.set` is likely becoming restricted syntax with types subworkflows, so we should avoid using it going forward: https://docs.seqera.io/nextflow/workflow-typed#restricted-syntax. 

### Changed

- Updated contribution guidelines regarding `.set` which might soon be restricted

