### PR TITLE
Migrate chromograph workflow outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1062](https://github.com/genomic-medicine-sweden/nallo/pull/1062) - Updated contribution guidelines regarding `.set` which might soon be restricted
 - [#1063](https://github.com/genomic-medicine-sweden/nallo/pull/1063) - Updated contribution guidelines regarding sorting include statements alphabetically
 - [#1064](https://github.com/genomic-medicine-sweden/nallo/pull/1064) - Changed `prepare_gens_inputs` to workflow outputs
-- [#](https://github.com/genomic-medicine-sweden/nallo/pull/) - Changed `chromograph` to workflow outputs
+- [#1067](https://github.com/genomic-medicine-sweden/nallo/pull/1067) - Changed `chromograph` to workflow outputs
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1062](https://github.com/genomic-medicine-sweden/nallo/pull/1062) - Updated contribution guidelines regarding `.set` which might soon be restricted
 - [#1063](https://github.com/genomic-medicine-sweden/nallo/pull/1063) - Updated contribution guidelines regarding sorting include statements alphabetically
 - [#1064](https://github.com/genomic-medicine-sweden/nallo/pull/1064) - Changed `prepare_gens_inputs` to workflow outputs
+- [#](https://github.com/genomic-medicine-sweden/nallo/pull/) - Changed `chromograph` to workflow outputs
 
 ### Removed
 

--- a/conf/modules/chromograph.config
+++ b/conf/modules/chromograph.config
@@ -1,5 +1,5 @@
 process {
-    withName: '.*NALLO:CHROMOGRAPH.*' {
+    withName: '.*:CHROMOGRAPH:.*' {
         publishDir = [
             enabled: false
         ]

--- a/conf/modules/chromograph.config
+++ b/conf/modules/chromograph.config
@@ -41,13 +41,5 @@ process {
     }
     withName: '.*CHROMOGRAPH:RUN_CHROMOGRAPH' {
         ext.args = '--euploid'
-        publishDir = [
-            path: {
-                def sample_id = meta.id ?: meta2.id
-                "${params.outdir}/images/chromograph/sample/${sample_id}/"
-            },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
-        ]
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -243,6 +243,7 @@ workflow GENOMICMEDICINESWEDEN_NALLO {
     annotated_paralogs = NALLO.out.annotated_paralogs // channel: [ val(meta), path(tsv/json) ]
     annotated_repeats = NALLO.out.annotated_repeats // channel: [ val(meta), path(vcf), path(tbi) ]
     assembly_summary = NALLO.out.assembly_summary // channel: [ val(meta), path(assembly_summary) ]
+    chromograph_plots = NALLO.out.chromograph_plots // channel: [ val(meta), path(png) ]
     gens_baf = NALLO.out.gens_baf // channel: [ val(meta), path(baf.bed.gz), path(baf.bed.gz.tbi) ]
     gens_cov = NALLO.out.gens_cov // channel: [ val(meta), path(cov.bed.gz), path(cov.bed.gz.tbi) ]
     methylation_annotation = NALLO.out.methylation_annotation // channel: [ val(meta), path(methylated_regions_by_family) ]
@@ -486,6 +487,7 @@ workflow {
     annotated_paralogs = GENOMICMEDICINESWEDEN_NALLO.out.annotated_paralogs // channel: [ val(meta), path(tsv/json) ]
     annotated_repeats = GENOMICMEDICINESWEDEN_NALLO.out.annotated_repeats // channel: [ val(meta), path(vcf), path(tbi) ]
     assembly_summary = GENOMICMEDICINESWEDEN_NALLO.out.assembly_summary // channel: [ val(meta), path(assembly_summary) ]
+    chromograph_plots = GENOMICMEDICINESWEDEN_NALLO.out.chromograph_plots // channel: [ val(meta), path(png) ]
     gens = ch_gens // channel: [ val(meta), path(baf/cov.bed.gz), path(baf/cov.bed.gz.tbi) ]
     methylation_annotation = GENOMICMEDICINESWEDEN_NALLO.out.methylation_annotation // channel: [ val(meta), path(methylated_regions_by_family) ]
     qc_cramino_unphased = ch_qc_cramino_unphased // channel: [ val(meta), path(txt/arrow) ]
@@ -510,6 +512,9 @@ output {
     }
     assembly_summary {
         path { meta, _assembly_summary -> "assembly/stats/${meta.id}/" }
+    }
+    chromograph_plots {
+        path { meta, _plot -> "images/chromograph/sample/${meta.id}/" }
     }
     gens {
         path { meta, _bed, _tbi -> "gens/${meta.id}/" }

--- a/subworkflows/local/chromograph/main.nf
+++ b/subworkflows/local/chromograph/main.nf
@@ -81,7 +81,10 @@ workflow CHROMOGRAPH {
             autozyg_meta.id == coverage_meta.id
         }
         .multiMap { autozyg_meta, autozyg, coverage_meta, coverage ->
-            autozyg: [autozyg_meta, autozyg]
+            // The module emits metadata from its first input, so coverage-only runs
+            // need the coverage metadata there for workflow output publishing.
+            def plot_meta = autozyg_meta ?: coverage_meta
+            autozyg: [plot_meta, autozyg]
             coverage: [coverage_meta, coverage]
         }
         .set { ch_chromograph_input }

--- a/subworkflows/local/chromograph/tests/main.nf.test
+++ b/subworkflows/local/chromograph/tests/main.nf.test
@@ -108,6 +108,7 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
+                { assert workflow.out.chromograph_plots.every { meta, _plots -> meta.id == 'HG003' } },
                 { assert snapshot(workflow.out).match() }
             )
         }
@@ -228,6 +229,7 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
+                { assert workflow.out.chromograph_plots.every { meta, _plots -> meta.id == 'HG003' } },
                 { assert snapshot(workflow.out).match() }
             )
         }

--- a/subworkflows/local/chromograph/tests/main.nf.test.snap
+++ b/subworkflows/local/chromograph/tests/main.nf.test.snap
@@ -10,20 +10,20 @@
                 ]
             }
         ],
+        "timestamp": "2026-03-27T16:54:52.939186031",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-27T16:54:52.939186031"
+        }
     },
     "plot coverage -stub": {
         "content": [
             {
                 "0": [
                     [
-                        [
-                            
-                        ],
+                        {
+                            "id": "HG003"
+                        },
                         [
                             "HG003_tiddit_cov.wig_chr1.png:md5,d41d8cd98f00b204e9800998ecf8427e",
                             "HG003_tiddit_cov.wig_chr10.png:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -55,9 +55,9 @@
                 ],
                 "chromograph_plots": [
                     [
-                        [
-                            
-                        ],
+                        {
+                            "id": "HG003"
+                        },
                         [
                             "HG003_tiddit_cov.wig_chr1.png:md5,d41d8cd98f00b204e9800998ecf8427e",
                             "HG003_tiddit_cov.wig_chr10.png:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -89,11 +89,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-05-05T10:02:35.292441318",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-27T16:55:19.631950502"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "plot nothing -stub": {
         "content": [
@@ -106,11 +106,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-03-27T16:55:45.040740805",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-27T16:55:45.040740805"
+        }
     },
     "plot all": {
         "content": [
@@ -237,11 +237,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-03-27T16:54:09.762099358",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-27T16:54:09.762099358"
+        }
     },
     "plot all -stub": {
         "content": [
@@ -368,11 +368,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-03-27T16:55:07.684265465",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-27T16:55:07.684265465"
+        }
     },
     "plot autozygosity -stub": {
         "content": [
@@ -449,20 +449,20 @@
                 ]
             }
         ],
+        "timestamp": "2026-03-27T16:55:33.722175984",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-27T16:55:33.722175984"
+        }
     },
     "plot coverage": {
         "content": [
             {
                 "0": [
                     [
-                        [
-                            
-                        ],
+                        {
+                            "id": "HG003"
+                        },
                         [
                             "HG003_tiddit_cov_chr1.png:md5,954482b960865332f37d386da5c9fb75",
                             "HG003_tiddit_cov_chr10.png:md5,954482b960865332f37d386da5c9fb75",
@@ -494,9 +494,9 @@
                 ],
                 "chromograph_plots": [
                     [
-                        [
-                            
-                        ],
+                        {
+                            "id": "HG003"
+                        },
                         [
                             "HG003_tiddit_cov_chr1.png:md5,954482b960865332f37d386da5c9fb75",
                             "HG003_tiddit_cov_chr10.png:md5,954482b960865332f37d386da5c9fb75",
@@ -528,11 +528,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-05-05T10:00:47.307586287",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-27T16:54:23.93536108"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "plot autozygosity": {
         "content": [
@@ -609,10 +609,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-03-27T16:54:40.428751555",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-27T16:54:40.428751555"
+        }
     }
 }

--- a/workflows/nallo.nf
+++ b/workflows/nallo.nf
@@ -1117,6 +1117,7 @@ workflow NALLO {
     annotated_paralogs = val_skip_annotate_paralogs ? channel.empty () : ANNOTATE_PARALOGS.out.tsv.mix(ANNOTATE_PARALOGS.out.json) // channel: [ val(meta), path(tsv/json) ]
     annotated_repeats = val_skip_repeat_annotation ? channel.empty() : ANNOTATE_REPEAT_EXPANSIONS.out.vcf.join(ANNOTATE_REPEAT_EXPANSIONS.out.tbi) // channel: [ val(meta), path(vcf), path(tbi) ]
     assembly_summary = val_skip_genome_assembly ? channel.empty() : GENOME_ASSEMBLY.out.assembly_summary // channel: [ val(meta), path(assembly_summary) ]
+    chromograph_plots = val_skip_chromograph ? channel.empty() : CHROMOGRAPH.out.chromograph_plots // channel: [ val(meta), path(png) ]
     gens_baf = val_skip_prepare_gens_input ? channel.empty() : PREPARE_GENS_INPUTS.out.baf_bed_tbi // channel: [ val(meta), path(baf.bed.gz), path(baf.bed.gz.tbi) ]
     gens_cov = val_skip_prepare_gens_input ? channel.empty() : PREPARE_GENS_INPUTS.out.cov_bed_tbi // channel: [ val(meta), path(cov.bed.gz), path(cov.bed.gz.tbi) ]
     methylation_annotation = val_skip_methylation_annotation ? channel.empty() : ANNOTATE_METHYLATION.out.methylation_annotation // channel: [ val(meta), path(methylated_regions_by_family) ]


### PR DESCRIPTION
## Description

closes #997 

### Added

- Test for `meta.id` presence in process output for chromograph coverage-only runs

### Changed

- Migrate `chromograph` to workflow outputs

