### PR TITLE
Move CRAM output test to run on PRs to dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1067](https://github.com/genomic-medicine-sweden/nallo/pull/1067) - Changed `chromograph` to workflow outputs
 - [#1069](https://github.com/genomic-medicine-sweden/nallo/pull/1069) - Changed `vcf_concat_norm_variants` to workflow outputs
 - [#1070](https://github.com/genomic-medicine-sweden/nallo/pull/1070) - Changed `call_methylation_modkit` to workflow outputs
+- [#1077](https://github.com/genomic-medicine-sweden/nallo/pull/1077) - Moved testing of CRAM output from `samplehsheet_target_regions_null` to `samplesheet` so it not only runs on PRs to the master branch
 
 ### Removed
 

--- a/tests/samplesheet.nf.test
+++ b/tests/samplesheet.nf.test
@@ -12,6 +12,7 @@ nextflow_pipeline {
                 pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
                 input                        = "$projectDir/assets/samplesheet.csv"
                 outdir                       = "$outputDir"
+                alignment_output_format      = "cram"
                 sv_callers                   = "sawfish,severus,hificnv"
                 sv_callers_to_run            = "sawfish,severus,hificnv,sniffles"
             }

--- a/tests/samplesheet.nf.test.snap
+++ b/tests/samplesheet.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "test profile": {
         "content": [
-            230,
+            234,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -212,6 +212,9 @@
                     "create_pedigree_file": 1.0,
                     "python": "3.8.3"
                 },
+                "SAMTOOLS_CONVERT": {
+                    "samtools": "1.23.1"
+                },
                 "SAMTOOLS_FAIDX": {
                     "samtools": "1.23.1"
                 },
@@ -321,13 +324,13 @@
             [
                 "aligned_reads",
                 "aligned_reads/HG002_Revio",
-                "aligned_reads/HG002_Revio/HG002_Revio_haplotagged.bam",
-                "aligned_reads/HG002_Revio/HG002_Revio_haplotagged.bam.bai",
+                "aligned_reads/HG002_Revio/HG002_Revio_haplotagged.cram",
+                "aligned_reads/HG002_Revio/HG002_Revio_haplotagged.cram.crai",
                 "assembly",
                 "assembly/sample",
                 "assembly/sample/HG002_Revio",
-                "assembly/sample/HG002_Revio/HG002_Revio_aligned_assembly.bam",
-                "assembly/sample/HG002_Revio/HG002_Revio_aligned_assembly.bam.bai",
+                "assembly/sample/HG002_Revio/HG002_Revio_aligned_assembly.cram",
+                "assembly/sample/HG002_Revio/HG002_Revio_aligned_assembly.cram.crai",
                 "assembly/stats",
                 "assembly/stats/HG002_Revio",
                 "assembly/stats/HG002_Revio/HG002_Revio_haplotype_1.assembly_summary",
@@ -555,8 +558,8 @@
                 "paraphase/family/FAM/FAM_paraphase_merged.vcf.gz.tbi",
                 "paraphase/sample",
                 "paraphase/sample/HG002_Revio",
-                "paraphase/sample/HG002_Revio/HG002_Revio.paraphase.bam",
-                "paraphase/sample/HG002_Revio/HG002_Revio.paraphase.bam.bai",
+                "paraphase/sample/HG002_Revio/HG002_Revio.paraphase.cram",
+                "paraphase/sample/HG002_Revio/HG002_Revio.paraphase.cram.crai",
                 "paraphase/sample/HG002_Revio/HG002_Revio.paraphase.json",
                 "paraphase/sample/HG002_Revio/HG002_Revio_paraphase_vcfs",
                 "paraphase/sample/HG002_Revio/HG002_Revio_paraphase_vcfs/HG002_Revio_OR1D5.vcf.gz",
@@ -628,8 +631,8 @@
                 "repeats/family/FAM/FAM_repeats_annotated.vcf.gz.tbi",
                 "repeats/sample",
                 "repeats/sample/HG002_Revio",
-                "repeats/sample/HG002_Revio/HG002_Revio_spanning_trgt.bam",
-                "repeats/sample/HG002_Revio/HG002_Revio_spanning_trgt.bam.bai",
+                "repeats/sample/HG002_Revio/HG002_Revio_spanning_trgt.cram",
+                "repeats/sample/HG002_Revio/HG002_Revio_spanning_trgt.cram.crai",
                 "repeats/sample/HG002_Revio/HG002_Revio_trgt.vcf.gz",
                 "repeats/sample/HG002_Revio/HG002_Revio_trgt.vcf.gz.tbi",
                 "snvs",
@@ -786,21 +789,21 @@
                 "HG002_Revio_pbcpgtools.hap2.bw:md5,f712cbadf2757e85641be0171b21b54d"
             ],
             [
+                
+            ],
+            [
                 [
-                    "HG002_Revio_haplotagged.bam",
+                    "HG002_Revio_haplotagged.cram",
                     "4914da895c558bc7a096ad9969bebf3f"
                 ],
                 [
-                    "HG002_Revio_aligned_assembly.bam",
+                    "HG002_Revio_aligned_assembly.cram",
                     "cecfa99c1c666ab3aa441b7c3c4ac05f"
                 ],
                 [
-                    "HG002_Revio_spanning_trgt.bam",
+                    "HG002_Revio_spanning_trgt.cram",
                     "f69e07c85d0f734408af24471f35792c"
                 ]
-            ],
-            [
-
             ],
             [
                 [
@@ -841,13 +844,13 @@
                 ]
             ],
             [
-
+                
             ]
         ],
-        "timestamp": "2026-04-24T13:15:21.371942263",
+        "timestamp": "2026-05-07T07:49:21.065543817",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.03.2"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/samplesheet_target_regions_null.nf.test
+++ b/tests/samplesheet_target_regions_null.nf.test
@@ -14,7 +14,6 @@ nextflow_pipeline {
                 outdir                       = "$outputDir"
                 target_regions               = null
                 sv_callers_to_run            = "severus,hificnv,sniffles"
-                alignment_output_format      = 'cram'
             }
         }
 

--- a/tests/samplesheet_target_regions_null.nf.test.snap
+++ b/tests/samplesheet_target_regions_null.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "test profile | --target_regions null --alignment_output_format cram": {
         "content": [
-            229,
+            225,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -212,9 +212,6 @@
                     "create_pedigree_file": 1.0,
                     "python": "3.8.3"
                 },
-                "SAMTOOLS_CONVERT": {
-                    "samtools": "1.23.1"
-                },
                 "SAMTOOLS_FAIDX": {
                     "samtools": "1.23.1"
                 },
@@ -318,13 +315,13 @@
             [
                 "aligned_reads",
                 "aligned_reads/HG002_Revio",
-                "aligned_reads/HG002_Revio/HG002_Revio_haplotagged.cram",
-                "aligned_reads/HG002_Revio/HG002_Revio_haplotagged.cram.crai",
+                "aligned_reads/HG002_Revio/HG002_Revio_haplotagged.bam",
+                "aligned_reads/HG002_Revio/HG002_Revio_haplotagged.bam.bai",
                 "assembly",
                 "assembly/sample",
                 "assembly/sample/HG002_Revio",
-                "assembly/sample/HG002_Revio/HG002_Revio_aligned_assembly.cram",
-                "assembly/sample/HG002_Revio/HG002_Revio_aligned_assembly.cram.crai",
+                "assembly/sample/HG002_Revio/HG002_Revio_aligned_assembly.bam",
+                "assembly/sample/HG002_Revio/HG002_Revio_aligned_assembly.bam.bai",
                 "assembly/stats",
                 "assembly/stats/HG002_Revio",
                 "assembly/stats/HG002_Revio/HG002_Revio_haplotype_1.assembly_summary",
@@ -552,8 +549,8 @@
                 "paraphase/family/FAM/FAM_paraphase_merged.vcf.gz.tbi",
                 "paraphase/sample",
                 "paraphase/sample/HG002_Revio",
-                "paraphase/sample/HG002_Revio/HG002_Revio.paraphase.cram",
-                "paraphase/sample/HG002_Revio/HG002_Revio.paraphase.cram.crai",
+                "paraphase/sample/HG002_Revio/HG002_Revio.paraphase.bam",
+                "paraphase/sample/HG002_Revio/HG002_Revio.paraphase.bam.bai",
                 "paraphase/sample/HG002_Revio/HG002_Revio.paraphase.json",
                 "paraphase/sample/HG002_Revio/HG002_Revio_paraphase_vcfs",
                 "paraphase/sample/HG002_Revio/HG002_Revio_paraphase_vcfs/HG002_Revio_OR1D5.vcf.gz",
@@ -625,8 +622,8 @@
                 "repeats/family/FAM/FAM_repeats_annotated.vcf.gz.tbi",
                 "repeats/sample",
                 "repeats/sample/HG002_Revio",
-                "repeats/sample/HG002_Revio/HG002_Revio_spanning_trgt.cram",
-                "repeats/sample/HG002_Revio/HG002_Revio_spanning_trgt.cram.crai",
+                "repeats/sample/HG002_Revio/HG002_Revio_spanning_trgt.bam",
+                "repeats/sample/HG002_Revio/HG002_Revio_spanning_trgt.bam.bai",
                 "repeats/sample/HG002_Revio/HG002_Revio_trgt.vcf.gz",
                 "repeats/sample/HG002_Revio/HG002_Revio_trgt.vcf.gz.tbi",
                 "snvs",
@@ -775,21 +772,21 @@
                 "HG002_Revio_pbcpgtools.hap2.bw:md5,52cd2aa1722314a581424ccde09a4d96"
             ],
             [
-
-            ],
-            [
                 [
-                    "HG002_Revio_haplotagged.cram",
+                    "HG002_Revio_haplotagged.bam",
                     "4914da895c558bc7a096ad9969bebf3f"
                 ],
                 [
-                    "HG002_Revio_aligned_assembly.cram",
+                    "HG002_Revio_aligned_assembly.bam",
                     "cecfa99c1c666ab3aa441b7c3c4ac05f"
                 ],
                 [
-                    "HG002_Revio_spanning_trgt.cram",
+                    "HG002_Revio_spanning_trgt.bam",
                     "f69e07c85d0f734408af24471f35792c"
                 ]
+            ],
+            [
+                
             ],
             [
                 [
@@ -830,13 +827,13 @@
                 ]
             ],
             [
-
+                
             ]
         ],
-        "timestamp": "2026-04-27T13:47:30.809872878",
+        "timestamp": "2026-05-07T07:51:47.634781122",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.03.1"
+            "nextflow": "26.04.0"
         }
     }
 }


### PR DESCRIPTION
## Description

Closes #1076 

### Changed

 - Move CRAM output from `samplehsheet_target_regions_null` to `samplesheet` test so it run on PRs to dev
