### PR TITLE
Remove reference to test-file that no longer exists

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -68,8 +68,6 @@ jobs:
             runCleanup: true
           - tag: "samplesheet_multisample_ont_bam"
             runCleanup: true
-          - tag: "samplesheet_stub"
-            runCleanup: true
           - tag: "samplesheet_target_regions_null"
             runCleanup: true
           - tag: "call_svs"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1041](https://github.com/genomic-medicine-sweden/nallo/pull/1041) - Changed `annotate_repeat_expansions` to workflow outputs
 - [#1047](https://github.com/genomic-medicine-sweden/nallo/pull/1047) - Changed `genome_assembly` to workflow outputs
 - [#1050](https://github.com/genomic-medicine-sweden/nallo/pull/1050) - Changed version to 0.13.0dev
-- [#1051](https://github.com/genomic-medicine-sweden/nallo/pull/1051) - Split `samplesheet_stub` test into six separate test files
+- [#1051](https://github.com/genomic-medicine-sweden/nallo/pull/1051), [#1078](https://github.com/genomic-medicine-sweden/nallo/pull/1078) - Split `samplesheet_stub` test into six separate test files
 - [#1054](https://github.com/genomic-medicine-sweden/nallo/pull/1054) - Changed `qc_aligned_reads` to workflow outputs
 - [#1058](https://github.com/genomic-medicine-sweden/nallo/pull/1058) - Update nf-test in CI to 0.9.5
 - [#1059](https://github.com/genomic-medicine-sweden/nallo/pull/1059) - Changed `qc_phasing` to workflow outputs


### PR DESCRIPTION
## Description

The `samplesheet_stub` test was removed in https://github.com/genomic-medicine-sweden/nallo/pull/1051, but `.github/workflows/nf-test.yml` is still referencing it, causing an (empty) GitHub action to run:

<img width="243" height="42" alt="Screenshot 2026-05-07 at 08 07 16" src="https://github.com/user-attachments/assets/c3680e44-4c40-4007-8244-cf0641d61a70" />

### Removed

- Removed reference to test-file that no longer exists
