### PR TITLE
Update testdata to include updated rank model without `most_severe_consequence`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1095](https://github.com/genomic-medicine-sweden/nallo/pull/1095) - Simplified peddy-related conditionals in `nallo`
 - [#1096](https://github.com/genomic-medicine-sweden/nallo/pull/1096) - Simplified cram-related conditionals in `nallo`
 - [#1097](https://github.com/genomic-medicine-sweden/nallo/pull/1097) - Simplified phasing-related if statement in `nallo`
+- [#1102](https://github.com/genomic-medicine-sweden/nallo/pull/1102) - Updated testdata commit with new genmod score config
 
 ### Removed
 

--- a/assets/echtvar_snv_databases.csv
+++ b/assets/echtvar_snv_databases.csv
@@ -1,3 +1,3 @@
 sample,file
-cadd,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/reference/cadd.v1.6.hg38.test_data.zip
-gnomad,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/reference/gnomad_af.zip
+cadd,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/reference/cadd.v1.6.hg38.test_data.zip
+gnomad,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/reference/gnomad_af.zip

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,2 +1,2 @@
 project,sample,file,family_id,paternal_id,maternal_id,sex,phenotype
-test,HG002_Revio,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.fastq.gz,FAM,0,0,0,2
+test,HG002_Revio,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.fastq.gz,FAM,0,0,0,2

--- a/assets/samplesheet_multisample_bam.csv
+++ b/assets/samplesheet_multisample_bam.csv
@@ -1,5 +1,5 @@
 project,sample,file,family_id,paternal_id,maternal_id,sex,phenotype
-test,HG003,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam,FAM,0,0,1,1
-test,HG002,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam,FAM,HG003,HG004,1,2
-test,HG002,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio_copy.bam,FAM,HG003,HG004,1,2
-test,HG004,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam,FAM,0,0,2,1
+test,HG003,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam,FAM,0,0,1,1
+test,HG002,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam,FAM,HG003,HG004,1,2
+test,HG002,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio_copy.bam,FAM,HG003,HG004,1,2
+test,HG004,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam,FAM,0,0,2,1

--- a/assets/samplesheet_multisample_ont_bam.csv
+++ b/assets/samplesheet_multisample_ont_bam.csv
@@ -1,5 +1,5 @@
 project,sample,file,family_id,paternal_id,maternal_id,sex,phenotype
-test,HG002_ONT_A,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT.bam,FAM,0,0,1,2
-test,HG002_ONT_B,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT.bam,FAM,0,0,1,1
-test,HG002_ONT_B,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT_copy.bam,FAM,0,0,1,1
-test,HG002_ONT_C,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT.bam,FAM2,0,0,1,2
+test,HG002_ONT_A,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT.bam,FAM,0,0,1,2
+test,HG002_ONT_B,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT.bam,FAM,0,0,1,1
+test,HG002_ONT_B,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT_copy.bam,FAM,0,0,1,1
+test,HG002_ONT_C,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT.bam,FAM2,0,0,1,2

--- a/assets/samplesheet_ont.csv
+++ b/assets/samplesheet_ont.csv
@@ -1,2 +1,2 @@
 sample,file,family_id,paternal_id,maternal_id,sex,phenotype
-HG002_ONT,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT.bam,FAM,0,0,1,2
+HG002_ONT,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT.bam,FAM,0,0,1,2

--- a/assets/samplesheet_same_sample_and_family_id.csv
+++ b/assets/samplesheet_same_sample_and_family_id.csv
@@ -1,2 +1,2 @@
 project,sample,file,family_id,paternal_id,maternal_id,sex,phenotype
-test,HG002_Revio,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.fastq.gz,HG002_Revio,0,0,1,2
+test,HG002_Revio,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.fastq.gz,HG002_Revio,0,0,1,2

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -120,7 +120,7 @@ Less common options for the pipeline, typically set in a config file.
 | `multiqc_logo` | Custom logo file to supply to MultiQC. File name must also be set in the MultiQC config file | `string` |  |  | True |
 | `multiqc_methods_description` | Custom MultiQC yaml file containing HTML including a methods description. | `string` |  |  |  |
 | `validate_params` | Boolean whether to validate parameters against the schema at runtime | `boolean` | True |  | True |
-| `pipelines_testdata_base_path` | Base URL or local path to location of pipeline test dataset files | `string` | https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/ |  | True |
+| `pipelines_testdata_base_path` | Base URL or local path to location of pipeline test dataset files | `string` | https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/ |  | True |
 | `trace_report_suffix` | Suffix to add to the trace report filename. Default is the date and time in the format yyyy-MM-dd_HH-mm-ss. | `string` |  |  | True |
 | `help` | Display the help message. | `['boolean', 'string']` |  |  |  |
 | `help_full` | Display the full detailed help message. | `boolean` |  |  |  |

--- a/nextflow.config
+++ b/nextflow.config
@@ -190,7 +190,7 @@ params {
     show_hidden                  = false
     version                      = false
     modules_testdata_base_path   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
-    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
+    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/'
     trace_report_suffix          = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')// Config options
 
     // Config options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -593,7 +593,7 @@
                     "type": "string",
                     "fa_icon": "far fa-check-circle",
                     "description": "Base URL or local path to location of pipeline test dataset files",
-                    "default": "https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/",
+                    "default": "https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/",
                     "hidden": true
                 },
                 "trace_report_suffix": {

--- a/subworkflows/local/bam_infer_sex/tests/main.nf.test.snap
+++ b/subworkflows/local/bam_infer_sex/tests/main.nf.test.snap
@@ -15,7 +15,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam"
                     ]
                 ],
                 "1": [
@@ -31,7 +31,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "2": [
@@ -47,8 +47,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "3": [
@@ -88,7 +88,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "bam": [
@@ -104,7 +104,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam"
                     ]
                 ],
                 "bam_bai": [
@@ -120,8 +120,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "somalier_html": [
@@ -172,7 +172,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ],
                     [
                         {
@@ -186,7 +186,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam"
                     ],
                     [
                         {
@@ -200,7 +200,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam"
                     ]
                 ],
                 "1": [
@@ -216,7 +216,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -230,7 +230,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -244,7 +244,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "2": [
@@ -260,8 +260,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -275,8 +275,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -290,8 +290,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "3": [
@@ -331,7 +331,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -345,7 +345,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -359,7 +359,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "bam": [
@@ -375,7 +375,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ],
                     [
                         {
@@ -389,7 +389,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam"
                     ],
                     [
                         {
@@ -403,7 +403,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam"
                     ]
                 ],
                 "bam_bai": [
@@ -419,8 +419,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -434,8 +434,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -449,8 +449,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "somalier_html": [
@@ -501,7 +501,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ]
                 ],
                 "1": [
@@ -517,7 +517,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "2": [
@@ -533,8 +533,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "3": [
@@ -574,7 +574,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "bam": [
@@ -590,7 +590,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ]
                 ],
                 "bam_bai": [
@@ -606,8 +606,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "somalier_html": [
@@ -658,7 +658,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ],
                     [
                         {
@@ -672,7 +672,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam"
                     ],
                     [
                         {
@@ -686,7 +686,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam"
                     ]
                 ],
                 "1": [
@@ -702,7 +702,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -716,7 +716,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -730,7 +730,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "2": [
@@ -746,8 +746,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -761,8 +761,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -776,8 +776,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "3": [
@@ -817,7 +817,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -831,7 +831,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -845,7 +845,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "bam": [
@@ -861,7 +861,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ],
                     [
                         {
@@ -875,7 +875,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam"
                     ],
                     [
                         {
@@ -889,7 +889,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam"
                     ]
                 ],
                 "bam_bai": [
@@ -905,8 +905,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -920,8 +920,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG003_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG003_PacBio_Revio.bam.bai"
                     ],
                     [
                         {
@@ -935,8 +935,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG004_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG004_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "somalier_html": [
@@ -987,7 +987,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ]
                 ],
                 "1": [
@@ -1003,7 +1003,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "2": [
@@ -1019,8 +1019,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "3": [
@@ -1060,7 +1060,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "bam": [
@@ -1076,7 +1076,7 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ]
                 ],
                 "bam_bai": [
@@ -1092,8 +1092,8 @@
                             "n_files": 1,
                             "single_end": true
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam",
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam.bai"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam",
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam.bai"
                     ]
                 ],
                 "somalier_html": [

--- a/subworkflows/local/convert_input_files/tests/main.nf.test.snap
+++ b/subworkflows/local/convert_input_files/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test_bam"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ],
                     [
                         {
@@ -21,7 +21,7 @@
                         {
                             "id": "test_fastq"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT.fastq.gz"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT.fastq.gz"
                     ]
                 ],
                 "bam": [
@@ -29,7 +29,7 @@
                         {
                             "id": "test_bam"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ],
                     [
                         {
@@ -43,7 +43,7 @@
                         {
                             "id": "test_fastq"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT.fastq.gz"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT.fastq.gz"
                     ]
                 ]
             }
@@ -62,7 +62,7 @@
                         {
                             "id": "test_bam"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ]
                 ],
                 "1": [
@@ -76,7 +76,7 @@
                         {
                             "id": "test_fastq"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT.fastq.gz"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT.fastq.gz"
                     ]
                 ],
                 "bam": [
@@ -84,7 +84,7 @@
                         {
                             "id": "test_bam"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ]
                 ],
                 "fastq": [
@@ -98,7 +98,7 @@
                         {
                             "id": "test_fastq"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT.fastq.gz"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT.fastq.gz"
                     ]
                 ]
             }
@@ -117,7 +117,7 @@
                         {
                             "id": "test_bam"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ],
                     [
                         {
@@ -137,7 +137,7 @@
                         {
                             "id": "test_fastq"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT.fastq.gz"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT.fastq.gz"
                     ]
                 ],
                 "bam": [
@@ -145,7 +145,7 @@
                         {
                             "id": "test_bam"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ],
                     [
                         {
@@ -165,7 +165,7 @@
                         {
                             "id": "test_fastq"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT.fastq.gz"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT.fastq.gz"
                     ]
                 ]
             }
@@ -184,7 +184,7 @@
                         {
                             "id": "test_bam"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ]
                 ],
                 "1": [
@@ -192,7 +192,7 @@
                         {
                             "id": "test_fastq"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT.fastq.gz"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT.fastq.gz"
                     ]
                 ],
                 "bam": [
@@ -200,7 +200,7 @@
                         {
                             "id": "test_bam"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ]
                 ],
                 "fastq": [
@@ -208,7 +208,7 @@
                         {
                             "id": "test_fastq"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT.fastq.gz"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT.fastq.gz"
                     ]
                 ]
             }
@@ -227,7 +227,7 @@
                         {
                             "id": "test_bam"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ],
                     [
                         {
@@ -247,7 +247,7 @@
                         {
                             "id": "test_fastq"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT.fastq.gz"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT.fastq.gz"
                     ]
                 ],
                 "bam": [
@@ -255,7 +255,7 @@
                         {
                             "id": "test_bam"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_PacBio_Revio.bam"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_PacBio_Revio.bam"
                     ],
                     [
                         {
@@ -275,7 +275,7 @@
                         {
                             "id": "test_fastq"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/testdata/HG002_ONT.fastq.gz"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/testdata/HG002_ONT.fastq.gz"
                     ]
                 ]
             }

--- a/subworkflows/local/prepare_references/tests/main.nf.test.snap
+++ b/subworkflows/local/prepare_references/tests/main.nf.test.snap
@@ -420,7 +420,7 @@
                         },
                         [
                             [
-                                
+
                             ]
                         ]
                     ]
@@ -456,7 +456,7 @@
                         },
                         [
                             [
-                                
+
                             ]
                         ]
                     ]
@@ -493,7 +493,7 @@
                         {
                             "id": "hg38"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/reference/hg38.test.fa"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/reference/hg38.test.fa"
                     ]
                 ],
                 "3": [
@@ -520,7 +520,7 @@
                         {
                             "id": "hg38"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/reference/hg38.test.fa"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/reference/hg38.test.fa"
                     ]
                 ],
                 "mmi": [
@@ -574,7 +574,7 @@
                         {
                             "id": "hg38"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/reference/hg38.test.fa"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/reference/hg38.test.fa"
                     ]
                 ],
                 "3": [
@@ -625,7 +625,7 @@
                         {
                             "id": "hg38"
                         },
-                        "/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/reference/hg38.test.fa"
+                        "/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/reference/hg38.test.fa"
                     ]
                 ],
                 "mmi": [

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -13,7 +13,7 @@
 params {
     config_profile_name        = 'Test profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'
-    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
+    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/'
     modules_testdata_base_path   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
 
     // References

--- a/tests/samplesheet.nf.test
+++ b/tests/samplesheet.nf.test
@@ -9,7 +9,7 @@ nextflow_pipeline {
     test("test profile") {
         when {
             params {
-                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
+                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/'
                 input                        = "$projectDir/assets/samplesheet.csv"
                 outdir                       = "$outputDir"
                 alignment_output_format      = "cram"

--- a/tests/samplesheet_multisample_bam.nf.test
+++ b/tests/samplesheet_multisample_bam.nf.test
@@ -9,7 +9,7 @@ nextflow_pipeline {
 
         when {
             params {
-                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
+                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/'
                 input                        = "$projectDir/assets/samplesheet_multisample_bam.csv"
                 outdir                       = "$outputDir"
                 phaser                       = "hiphase"

--- a/tests/samplesheet_multisample_ont_bam.nf.test
+++ b/tests/samplesheet_multisample_ont_bam.nf.test
@@ -9,7 +9,7 @@ nextflow_pipeline {
 
         when {
             params {
-                pipelines_testdata_base_path   =  'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
+                pipelines_testdata_base_path   =  'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/'
                 input                          = "$projectDir/assets/samplesheet_multisample_ont_bam.csv"
                 outdir                         = "$outputDir"
                 preset                         = 'ONT_R10'

--- a/tests/samplesheet_target_regions_null.nf.test
+++ b/tests/samplesheet_target_regions_null.nf.test
@@ -9,7 +9,7 @@ nextflow_pipeline {
 
         when {
             params {
-                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
+                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/'
                 input                        = "$projectDir/assets/samplesheet.csv"
                 outdir                       = "$outputDir"
                 target_regions               = null

--- a/tests/stub_alignment_assembly.nf.test
+++ b/tests/stub_alignment_assembly.nf.test
@@ -12,7 +12,7 @@ nextflow_pipeline {
 
         when {
             params {
-                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
+                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/'
                 input                        = "$projectDir/assets/samplesheet.csv"
                 outdir                       = "$outputDir"
                 skip_genome_assembly         = true
@@ -59,7 +59,7 @@ nextflow_pipeline {
         options "-stub"
         when {
             params {
-                pipelines_testdata_base_path  = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
+                pipelines_testdata_base_path  = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/'
                 input                         = "$projectDir/assets/samplesheet.csv"
                 outdir                        = "$outputDir"
                 skip_genome_assembly          = true
@@ -107,7 +107,7 @@ nextflow_pipeline {
 
         when {
             params {
-                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
+                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/'
                 input                        = "$projectDir/assets/samplesheet.csv"
                 outdir                       = "$outputDir"
                 skip_alignment               = true

--- a/tests/stub_mock_resources.nf.test
+++ b/tests/stub_mock_resources.nf.test
@@ -12,7 +12,7 @@ nextflow_pipeline {
 
         when {
             params {
-                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
+                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/'
                 input                        = "$projectDir/assets/samplesheet.csv"
                 outdir                       = "$outputDir"
                 // Mock inputs for CADD
@@ -58,7 +58,7 @@ nextflow_pipeline {
 
         when {
             params {
-                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
+                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/'
                 input                        = "$projectDir/assets/samplesheet.csv"
                 outdir                       = "$outputDir"
                 // Mock inputs for VEP
@@ -104,7 +104,7 @@ nextflow_pipeline {
 
         when {
             params {
-                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
+                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/'
                 input                        = "$projectDir/assets/samplesheet.csv"
                 outdir                       = "$outputDir"
                 snv_caller                   = "sentieon"

--- a/tests/stub_same_family_and_sample_id.nf.test
+++ b/tests/stub_same_family_and_sample_id.nf.test
@@ -12,7 +12,7 @@ nextflow_pipeline {
 
         when {
             params {
-                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
+                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/'
                 input                        = "$projectDir/assets/samplesheet_same_sample_and_family_id.csv"
                 outdir                       = "$outputDir"
             }

--- a/tests/stub_sawfish_joint_call_single_sample.nf.test
+++ b/tests/stub_sawfish_joint_call_single_sample.nf.test
@@ -12,7 +12,7 @@ nextflow_pipeline {
 
         when {
             params {
-                pipelines_testdata_base_path            = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/59c411038dac1e4dab2d745c80d382f047433539/'
+                pipelines_testdata_base_path            = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/8fff73a86ec5c9360ed8da35aac5b108b9c9ef78/'
                 input                                   = "$projectDir/assets/samplesheet.csv"
                 outdir                                  = "$outputDir"
                 skip_annotate_paralogs                  = true


### PR DESCRIPTION
## Description

Update testdata commit to include rank model without most_severe_consequence, needed for https://github.com/genomic-medicine-sweden/nallo/pull/1098. Putting this in a separate PR so that #1098 becomes easier to review. 

https://github.com/genomic-medicine-sweden/test-datasets/pull/71 needs to be reviewed as well.

### Changed

- Updated testdata commit with new genmod score config
