### PR TITLE
remove samplesheet_ont.csv because it is unused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1087](https://github.com/genomic-medicine-sweden/nallo/pull/1087) - Removed empty qc_snv.config
 - [#1092](https://github.com/genomic-medicine-sweden/nallo/pull/1092) - Removed unused SVDB import in `nallo`
 - [#1100](https://github.com/genomic-medicine-sweden/nallo/pull/1100) - Removed tabix from SNV and SV annotation subworkflows
+- [#1125](https://github.com/genomic-medicine-sweden/nallo/pull/1125) - Removed `samplesheet_ont.csv` because it is unused.
 
 ### Fixed
 

--- a/assets/samplesheet_ont.csv
+++ b/assets/samplesheet_ont.csv
@@ -1,2 +1,0 @@
-sample,file,family_id,paternal_id,maternal_id,sex,phenotype
-HG002_ONT,https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/bcd63e7dc9025450aebbca7b859ba2dae1f5a3d3/testdata/HG002_ONT.bam,FAM,0,0,1,2


### PR DESCRIPTION
## Description

Closes https://github.com/genomic-medicine-sweden/nallo/issues/1121

### Removed

- Removed `samplesheet_ont.csv` because it is unused.
