### PR TITLE
Fix wrong param in sentieon-specific snv filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1045](https://github.com/genomic-medicine-sweden/nallo/pull/1045) - Fixed `--skip_sex_check` should depend on `--skip_alignment` in workflow checks on pipeline start.
 - [#1056](https://github.com/genomic-medicine-sweden/nallo/pull/1056) - Fixed nf-test CI not passing the matrix Nextflow version to the setup action.
 - [#1079](https://github.com/genomic-medicine-sweden/nallo/pull/1079) - Fixed typo in tests for `call_methylation_methbat`
+- [#1142](https://github.com/genomic-medicine-sweden/nallo/pull/1142) - Fixed Sentieon-specific SNV filtering to use the configured `--snv_caller` parameter
 
 ### Parameters
 

--- a/conf/modules/annotate_snvs.config
+++ b/conf/modules/annotate_snvs.config
@@ -27,7 +27,7 @@ process {
             // Drop spanning deletion ("*") alleles from Sentieon.
             // They are redundant (covered by upstream DELs) and break VEP annotation,
             // causing downstream MSC/PLI scripts to crash.
-            params.variant_caller == 'sentieon' ? '-e \'ALT="*"\'' : ''
+            params.snv_caller == 'sentieon' ? '-e \'ALT="*"\'' : ''
         ].join(" ") }
     }
 


### PR DESCRIPTION
## Description

### Fixed

- Fixed Sentieon-specific SNV filtering to use the configured `--snv_caller` parameter 