### PR TITLE
Add skip_call_mt_variants parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#1164](https://github.com/genomic-medicine-sweden/nallo/pull/1164) - Added `--skip_mitochondrial_calling` parameter to allow skipping mitochondrial variant calling
 - [#1042](https://github.com/genomic-medicine-sweden/nallo/pull/1042) - Added `somalier_html` output to `bam_infer_sex`
 - [#1047](https://github.com/genomic-medicine-sweden/nallo/pull/1047) - Added `assembly_summary` output to `genome_assembly` so that it can be used as a workflow output
 - [#1052](https://github.com/genomic-medicine-sweden/nallo/pull/1052) - Added new credit to README.md and new contributor to nextflow.config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [#1164](https://github.com/genomic-medicine-sweden/nallo/pull/1164) - Added `--skip_mitochondrial_calling` parameter to allow skipping mitochondrial variant calling
 - [#1042](https://github.com/genomic-medicine-sweden/nallo/pull/1042) - Added `somalier_html` output to `bam_infer_sex`
 - [#1047](https://github.com/genomic-medicine-sweden/nallo/pull/1047) - Added `assembly_summary` output to `genome_assembly` so that it can be used as a workflow output
 - [#1052](https://github.com/genomic-medicine-sweden/nallo/pull/1052) - Added new credit to README.md and new contributor to nextflow.config
@@ -23,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1025](https://github.com/genomic-medicine-sweden/nallo/pull/1025) - Added `call_mitochondrial_variants` subworkflow
 - [#1148](https://github.com/genomic-medicine-sweden/nallo/pull/1148) - Added tests for `annotate_consequence_pli`
 - [#1155](https://github.com/genomic-medicine-sweden/nallo/pull/1155) - Added Nallo paper to the README
+- [#1164](https://github.com/genomic-medicine-sweden/nallo/pull/1164) - Added `--skip_mitochondrial_calling` parameter to allow skipping mitochondrial variant calling
 
 ### Changed
 

--- a/main.nf
+++ b/main.nf
@@ -396,6 +396,7 @@ workflow {
         params.skip_genome_assembly,
         params.skip_methylation_calling,
         params.skip_methylation_annotation,
+        params.skip_mitochondrial_calling,
         params.skip_peddy,
         params.skip_phasing,
         params.skip_prepare_gens_input,

--- a/main.nf
+++ b/main.nf
@@ -114,6 +114,7 @@ workflow GENOMICMEDICINESWEDEN_NALLO {
     val_skip_rank_variants
     val_skip_repeat_annotation
     val_skip_repeat_calling
+    val_skip_mitochondrial_calling
     val_skip_sambamba_depth
     val_skip_sex_check
     val_skip_snv_annotation
@@ -219,6 +220,7 @@ workflow GENOMICMEDICINESWEDEN_NALLO {
         val_skip_qc,
         val_skip_rank_variants,
         val_skip_repeat_annotation,
+        val_skip_mitochondrial_calling,
         val_skip_sambamba_depth,
         val_skip_sex_check,
         val_skip_snv_annotation,
@@ -511,6 +513,7 @@ workflow {
         params.skip_rank_variants,
         params.skip_repeat_annotation,
         params.skip_repeat_calling,
+        params.skip_mitochondrial_calling,
         params.skip_sambamba_depth,
         params.skip_sex_check,
         params.skip_snv_annotation,

--- a/nextflow.config
+++ b/nextflow.config
@@ -96,6 +96,7 @@ params {
     skip_snv_annotation            = false
     skip_sv_annotation             = false
     skip_sv_calling                = false
+    skip_mitochondrial_calling     = false
     skip_sex_check                 = false
 
     deepvariant_model_type         = params.preset == 'ONT_R10' ? 'ONT_R104' : 'PACBIO'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -117,6 +117,11 @@
                     "description": "Skip preparing input data for Gens",
                     "default": false
                 },
+                "skip_mitochondrial_calling": {
+                    "type": "boolean",
+                    "description": "Skip mitochondrial variant calling",
+                    "default": false
+                },
                 "skip_sex_check": {
                     "type": "boolean",
                     "description": "Skip sex check",

--- a/subworkflows/local/utils_nfcore_nallo_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_nallo_pipeline/main.nf
@@ -58,6 +58,7 @@ workflow PIPELINE_INITIALISATION {
     val_skip_genome_assembly
     val_skip_methylation_calling
     val_skip_methylation_annotation
+    val_skip_mitochondrial_calling
     val_skip_peddy
     val_skip_phasing
     val_skip_prepare_gens_input
@@ -168,6 +169,7 @@ workflow PIPELINE_INITIALISATION {
         chromograph           : "skip_chromograph",
         methylation           : "skip_methylation_calling",
         methylation_annotation: "skip_methylation_annotation",
+        mitochondrial         : "skip_mitochondrial_calling",
         qc                    : "skip_qc",
         gens                  : "skip_prepare_gens_input",
         sex_check             : "skip_sex_check",
@@ -194,6 +196,7 @@ workflow PIPELINE_INITIALISATION {
         repeat_annotation     : ["mapping", "snv_calling", "phasing", "repeat_calling"],
         methylation           : ["mapping", "snv_calling"],
         methylation_annotation: ["mapping", "snv_calling", "methylation"],
+        mitochondrial         : ["mapping"],
         gens                  : ["mapping", "snv_calling"],
     ]
 
@@ -224,6 +227,7 @@ workflow PIPELINE_INITIALISATION {
             skip_phasing                : val_skip_phasing,
             skip_methylation_calling    : val_skip_methylation_calling,
             skip_methylation_annotation : val_skip_methylation_annotation,
+            skip_mitochondrial_calling  : val_skip_mitochondrial_calling,
             skip_rank_variants          : val_skip_rank_variants,
             skip_repeat_calling         : val_skip_repeat_calling,
             skip_repeat_annotation      : val_skip_repeat_annotation,

--- a/tests/stub_alignment_assembly.nf.test
+++ b/tests/stub_alignment_assembly.nf.test
@@ -82,7 +82,7 @@ nextflow_pipeline {
                 skip_methylation_calling      = true
                 skip_methylation_annotation   = true
                 skip_prepare_gens_input       = true
-                skip_mitochondrial_calling   = true
+                skip_mitochondrial_calling    = true
             }
         }
 

--- a/tests/stub_alignment_assembly.nf.test
+++ b/tests/stub_alignment_assembly.nf.test
@@ -34,6 +34,7 @@ nextflow_pipeline {
                 skip_methylation_annotation  = true
                 skip_methylation_calling     = true
                 skip_prepare_gens_input      = true
+                skip_mitochondrial_calling   = true
             }
         }
 
@@ -81,6 +82,7 @@ nextflow_pipeline {
                 skip_methylation_calling      = true
                 skip_methylation_annotation   = true
                 skip_prepare_gens_input       = true
+                skip_mitochondrial_calling   = true
             }
         }
 
@@ -129,6 +131,7 @@ nextflow_pipeline {
                 skip_methylation_calling     = true
                 skip_methylation_annotation  = true
                 skip_prepare_gens_input      = true
+                skip_mitochondrial_calling   = true
             }
         }
 

--- a/tests/stub_mock_resources.nf.test
+++ b/tests/stub_mock_resources.nf.test
@@ -34,6 +34,7 @@ nextflow_pipeline {
                 skip_methylation_calling     = true
                 skip_methylation_annotation  = true
                 skip_prepare_gens_input      = true
+                skip_mitochondrial_calling   = true
             }
         }
 
@@ -79,6 +80,7 @@ nextflow_pipeline {
                 skip_methylation_calling     = true
                 skip_methylation_annotation  = true
                 skip_prepare_gens_input      = true
+                skip_mitochondrial_calling   = true
             }
         }
 
@@ -131,6 +133,7 @@ nextflow_pipeline {
                 skip_methylation_calling     = true
                 skip_methylation_annotation  = true
                 skip_prepare_gens_input      = true
+                skip_mitochondrial_calling   = true
             }
         }
 

--- a/tests/stub_mock_resources.nf.test.snap
+++ b/tests/stub_mock_resources.nf.test.snap
@@ -1,14 +1,12 @@
 {
     "Test VEP with mock uncompressed cache": {
         "content": [
-            71,
+            55,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
                 },
-                "BCFTOOLS_MERGE": {
-                    "bcftools": 1.22
-                },
+
                 "BCFTOOLS_NORM_MULTISAMPLE": {
                     "bcftools": 1.22
                 },
@@ -21,9 +19,7 @@
                 "BCFTOOLS_STATS": {
                     "bcftools": 1.22
                 },
-                "BCFTOOLS_VIEW_MITO": {
-                    "bcftools": 1.22
-                },
+
                 "BEDTOOLS_MERGE": {
                     "bedtools": "2.31.1"
                 },
@@ -73,9 +69,7 @@
                 "MINIMAP2_INDEX": {
                     "minimap2": "2.29-r1283"
                 },
-                "MITORSAW_HAPLOTYPE": {
-                    "mitorsaw": "0.2.9-0dc8e58"
-                },
+
                 "RELATE_INFER": {
                     "somalier": "0.2.18"
                 },
@@ -162,14 +156,12 @@
     },
     "Test Sentieon SNV calling with mock resources": {
         "content": [
-            59,
+            43,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
                 },
-                "BCFTOOLS_MERGE": {
-                    "bcftools": 1.22
-                },
+
                 "BCFTOOLS_NORM_MULTISAMPLE": {
                     "bcftools": 1.22
                 },
@@ -185,9 +177,7 @@
                 "BCFTOOLS_STATS": {
                     "bcftools": 1.22
                 },
-                "BCFTOOLS_VIEW_MITO": {
-                    "bcftools": 1.22
-                },
+
                 "BEDTOOLS_INTERSECT": {
                     "bedtools": "2.31.1"
                 },
@@ -235,9 +225,7 @@
                 "MINIMAP2_INDEX": {
                     "minimap2": "2.29-r1283"
                 },
-                "MITORSAW_HAPLOTYPE": {
-                    "mitorsaw": "0.2.9-0dc8e58"
-                },
+
                 "RELATE_INFER": {
                     "somalier": "0.2.18"
                 },
@@ -327,7 +315,7 @@
     },
     "Test CADD with mock resources": {
         "content": [
-            89,
+            68,
             {
                 "ANNOTATE_INDELS": {
                     "bcftools": 1.22
@@ -335,9 +323,7 @@
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
                 },
-                "BCFTOOLS_MERGE": {
-                    "bcftools": 1.22
-                },
+
                 "BCFTOOLS_NORM_MULTISAMPLE": {
                     "bcftools": 1.22
                 },
@@ -353,9 +339,7 @@
                 "BCFTOOLS_VIEW": {
                     "bcftools": 1.22
                 },
-                "BCFTOOLS_VIEW_MITO": {
-                    "bcftools": 1.22
-                },
+
                 "BEDTOOLS_MERGE": {
                     "bedtools": "2.31.1"
                 },
@@ -411,9 +395,7 @@
                 "MINIMAP2_INDEX": {
                     "minimap2": "2.29-r1283"
                 },
-                "MITORSAW_HAPLOTYPE": {
-                    "mitorsaw": "0.2.9-0dc8e58"
-                },
+
                 "REFERENCE_TO_CADD_CHRNAMES": {
                     "gawk": "5.3.1"
                 },

--- a/tests/stub_same_family_and_sample_id.nf.test
+++ b/tests/stub_same_family_and_sample_id.nf.test
@@ -15,6 +15,7 @@ nextflow_pipeline {
                 pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/bcd63e7dc9025450aebbca7b859ba2dae1f5a3d3/'
                 input                        = "$projectDir/assets/samplesheet_same_sample_and_family_id.csv"
                 outdir                       = "$outputDir"
+                skip_mitochondrial_calling   = true
             }
         }
 

--- a/tests/stub_same_family_and_sample_id.nf.test.snap
+++ b/tests/stub_same_family_and_sample_id.nf.test.snap
@@ -90,10 +90,10 @@
                     "bgzip": 1.21
                 },
                 "DEEPVARIANT_RUNDEEPVARIANT": {
-                    "deepvariant": null
+                    "deepvariant": "1.10.0"
                 },
                 "DEEPVARIANT_VCFSTATSREPORT": {
-                    "deepvariant": null
+                    "deepvariant": "1.10.0"
                 },
                 "ECHTVAR_ANNO": {
                     "echtvar": "0.2.4"

--- a/tests/stub_same_family_and_sample_id.nf.test.snap
+++ b/tests/stub_same_family_and_sample_id.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "Test family id same as sample id": {
         "content": [
-            218,
+            192,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -40,9 +40,6 @@
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_CHROMOGRAPH": {
-                    "bcftools": 1.22
-                },
-                "BCFTOOLS_VIEW_MITO": {
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_PHASING": {
@@ -93,10 +90,10 @@
                     "bgzip": 1.21
                 },
                 "DEEPVARIANT_RUNDEEPVARIANT": {
-                    "deepvariant": "1.10.0"
+                    "deepvariant": null
                 },
                 "DEEPVARIANT_VCFSTATSREPORT": {
-                    "deepvariant": "1.10.0"
+                    "deepvariant": null
                 },
                 "ECHTVAR_ANNO": {
                     "echtvar": "0.2.4"
@@ -169,9 +166,6 @@
                 },
                 "MINIMAP2_INDEX": {
                     "minimap2": "2.29-r1283"
-                },
-                "MITORSAW_HAPLOTYPE": {
-                    "mitorsaw": "0.2.9-0dc8e58"
                 },
                 "MOSDEPTH": {
                     "mosdepth": "0.3.11"
@@ -517,10 +511,10 @@
                 "visualization_tracks/HG002_Revio/HG002_Revio_pbcpgtools.hap2.bw"
             ]
         ],
-        "timestamp": "2026-06-23T17:03:46.887525119",
+        "timestamp": "2026-07-05T21:56:22.137144",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.03.4"
+            "nextflow": "26.04.4"
         }
     }
 }

--- a/tests/stub_sawfish_joint_call_single_sample.nf.test
+++ b/tests/stub_sawfish_joint_call_single_sample.nf.test
@@ -32,6 +32,7 @@ nextflow_pipeline {
                 sv_callers_merge_priority               = "sawfish"
                 force_sawfish_joint_call_single_samples = true
                 skip_prepare_gens_input                 = true
+                skip_mitochondrial_calling   = true
             }
         }
 

--- a/tests/stub_sawfish_joint_call_single_sample.nf.test
+++ b/tests/stub_sawfish_joint_call_single_sample.nf.test
@@ -32,7 +32,7 @@ nextflow_pipeline {
                 sv_callers_merge_priority               = "sawfish"
                 force_sawfish_joint_call_single_samples = true
                 skip_prepare_gens_input                 = true
-                skip_mitochondrial_calling   = true
+                skip_mitochondrial_calling              = true
             }
         }
 

--- a/tests/stub_sawfish_joint_call_single_sample.nf.test.snap
+++ b/tests/stub_sawfish_joint_call_single_sample.nf.test.snap
@@ -37,10 +37,10 @@
                     "cramino": "1.1.0"
                 },
                 "DEEPVARIANT_RUNDEEPVARIANT": {
-                    "deepvariant": null
+                    "deepvariant": "1.10.0"
                 },
                 "DEEPVARIANT_VCFSTATSREPORT": {
-                    "deepvariant": null
+                    "deepvariant": "1.10.0"
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"

--- a/tests/stub_sawfish_joint_call_single_sample.nf.test.snap
+++ b/tests/stub_sawfish_joint_call_single_sample.nf.test.snap
@@ -1,13 +1,10 @@
 {
     "Test sawfish with force_sawfish_joint_call_single_samples true": {
         "content": [
-            65,
+            59,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
-                },
-                "BCFTOOLS_MERGE": {
-                    "bcftools": 1.22
                 },
                 "BCFTOOLS_NORM_MULTISAMPLE": {
                     "bcftools": 1.22
@@ -22,9 +19,6 @@
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW": {
-                    "bcftools": 1.22
-                },
-                "BCFTOOLS_VIEW_MITO": {
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_SV": {
@@ -43,10 +37,10 @@
                     "cramino": "1.1.0"
                 },
                 "DEEPVARIANT_RUNDEEPVARIANT": {
-                    "deepvariant": "1.10.0"
+                    "deepvariant": null
                 },
                 "DEEPVARIANT_VCFSTATSREPORT": {
-                    "deepvariant": "1.10.0"
+                    "deepvariant": null
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
@@ -74,9 +68,6 @@
                 },
                 "MINIMAP2_INDEX": {
                     "minimap2": "2.29-r1283"
-                },
-                "MITORSAW_HAPLOTYPE": {
-                    "mitorsaw": "0.2.9-0dc8e58"
                 },
                 "MOSDEPTH": {
                     "mosdepth": "0.3.11"
@@ -219,10 +210,10 @@
                 "visualization_tracks/test/test_maf_sawfish.bw"
             ]
         ],
-        "timestamp": "2026-06-01T09:50:49.410375208",
+        "timestamp": "2026-07-05T21:30:13.736637",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.03.4"
+            "nextflow": "26.04.4"
         }
     }
 }

--- a/tests/stub_sex_check.nf.test
+++ b/tests/stub_sex_check.nf.test
@@ -23,6 +23,7 @@ nextflow_pipeline {
                 skip_methylation_annotation  = true
                 skip_peddy                   = true
                 skip_prepare_gens_input      = true
+                skip_mitochondrial_calling   = true
                 skip_phasing                 = true
                 skip_rank_variants           = true
                 skip_repeat_calling          = true

--- a/tests/stub_sex_check.nf.test.snap
+++ b/tests/stub_sex_check.nf.test.snap
@@ -212,10 +212,10 @@
                     "csvtk": "0.31.0"
                 },
                 "DEEPVARIANT_RUNDEEPVARIANT": {
-                    "deepvariant": null
+                    "deepvariant": "1.10.0"
                 },
                 "DEEPVARIANT_VCFSTATSREPORT": {
-                    "deepvariant": null
+                    "deepvariant": "1.10.0"
                 },
                 "GATK4_DENOISEREADCOUNTS": {
                     "gatk4": "4.6.2.0"

--- a/tests/stub_sex_check.nf.test.snap
+++ b/tests/stub_sex_check.nf.test.snap
@@ -212,10 +212,10 @@
                     "csvtk": "0.31.0"
                 },
                 "DEEPVARIANT_RUNDEEPVARIANT": {
-                    "deepvariant": "1.10.0"
+                    "deepvariant": null
                 },
                 "DEEPVARIANT_VCFSTATSREPORT": {
-                    "deepvariant": "1.10.0"
+                    "deepvariant": null
                 },
                 "GATK4_DENOISEREADCOUNTS": {
                     "gatk4": "4.6.2.0"
@@ -485,10 +485,10 @@
                 "visualization_tracks/HG004/HG004_pbcpgtools.hap2.bw"
             ]
         ],
-        "timestamp": "2026-06-01T09:52:04.683544308",
+        "timestamp": "2026-07-05T19:53:44.033069",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.03.4"
+            "nextflow": "26.04.4"
         }
     }
 }

--- a/tests/stub_skip_mitochondrial_calling.nf.test
+++ b/tests/stub_skip_mitochondrial_calling.nf.test
@@ -1,0 +1,96 @@
+nextflow_pipeline {
+
+    name "Test pipeline GENOMICMEDICINESWEDEN_NALLO — Stub tests for skip_mitochondrial_calling"
+    script "../main.nf"
+    tag "PIPELINE"
+    tag "pipeline_stub"
+    tag "stub_skip_mitochondrial_calling"
+    config "./nextflow.config"
+
+    test("Test mitochondrial calling runs by default") {
+        options "-stub"
+
+        when {
+            params {
+                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/eaabae15e3ee2b074057363a7467469b09f0957e/'
+                input                        = "$projectDir/assets/samplesheet.csv"
+                outdir                       = "$outputDir"
+                skip_annotate_paralogs       = true
+                skip_call_paralogs           = true
+                skip_chromograph             = true
+                skip_genome_assembly         = true
+                skip_methylation_annotation  = true
+                skip_methylation_calling     = true
+                skip_peddy                   = true
+                skip_phasing                 = true
+                skip_prepare_gens_input      = true
+                skip_qc                      = true
+                skip_rank_variants           = true
+                skip_repeat_annotation       = true
+                skip_repeat_calling          = true
+                skip_sambamba_depth          = true
+                skip_snv_annotation          = true
+                skip_sv_annotation           = true
+                skip_sv_calling              = true
+            }
+        }
+
+        then {
+            def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
+            def versions = removeNextflowVersion("$outputDir/pipeline_info/nallo_software_mqc_versions.yml")
+            assertAll(
+                { assert workflow.success },
+                { assert versions.containsKey('MITORSAW_HAPLOTYPE') },
+                { assert snapshot(
+                    workflow.trace.succeeded().size(),
+                    versions,
+                    stable_name
+                ).match() }
+            )
+        }
+    }
+
+    test("Test skip_mitochondrial_calling") {
+        options "-stub"
+
+        when {
+            params {
+                pipelines_testdata_base_path = 'https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/eaabae15e3ee2b074057363a7467469b09f0957e/'
+                input                        = "$projectDir/assets/samplesheet.csv"
+                outdir                       = "$outputDir"
+                skip_annotate_paralogs       = true
+                skip_call_paralogs           = true
+                skip_chromograph             = true
+                skip_genome_assembly         = true
+                skip_methylation_annotation  = true
+                skip_methylation_calling     = true
+                skip_mitochondrial_calling   = true
+                skip_peddy                   = true
+                skip_phasing                 = true
+                skip_prepare_gens_input      = true
+                skip_qc                      = true
+                skip_rank_variants           = true
+                skip_repeat_annotation       = true
+                skip_repeat_calling          = true
+                skip_sambamba_depth          = true
+                skip_snv_annotation          = true
+                skip_sv_annotation           = true
+                skip_sv_calling              = true
+            }
+        }
+
+        then {
+            def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
+            def versions = removeNextflowVersion("$outputDir/pipeline_info/nallo_software_mqc_versions.yml")
+            assertAll(
+                { assert workflow.success },
+                { assert !versions.containsKey('MITORSAW_HAPLOTYPE') },
+                { assert snapshot(
+                    workflow.trace.succeeded().size(),
+                    versions,
+                    stable_name
+                ).match() }
+            )
+        }
+    }
+}

--- a/tests/stub_skip_mitochondrial_calling.nf.test.snap
+++ b/tests/stub_skip_mitochondrial_calling.nf.test.snap
@@ -28,10 +28,10 @@
                     "bedtools": "2.31.1"
                 },
                 "DEEPVARIANT_RUNDEEPVARIANT": {
-                    "deepvariant": null
+                    "deepvariant": "1.10.0"
                 },
                 "DEEPVARIANT_VCFSTATSREPORT": {
-                    "deepvariant": null
+                    "deepvariant": "1.10.0"
                 },
                 "GAWK_EXTRACT_REGIONS": {
                     "gawk": "5.3.1"
@@ -161,10 +161,10 @@
                     "bedtools": "2.31.1"
                 },
                 "DEEPVARIANT_RUNDEEPVARIANT": {
-                    "deepvariant": null
+                    "deepvariant": "1.10.0"
                 },
                 "DEEPVARIANT_VCFSTATSREPORT": {
-                    "deepvariant": null
+                    "deepvariant": "1.10.0"
                 },
                 "GAWK_EXTRACT_REGIONS": {
                     "gawk": "5.3.1"

--- a/tests/stub_skip_mitochondrial_calling.nf.test.snap
+++ b/tests/stub_skip_mitochondrial_calling.nf.test.snap
@@ -1,0 +1,265 @@
+{
+    "Test skip_mitochondrial_calling": {
+        "content": [
+            34,
+            {
+                "BCFTOOLS_CONCAT": {
+                    "bcftools": 1.21
+                },
+                "BCFTOOLS_NORM_MULTISAMPLE": {
+                    "bcftools": 1.22
+                },
+                "BCFTOOLS_NORM_SINGLESAMPLE": {
+                    "bcftools": 1.22
+                },
+                "BCFTOOLS_SORT": {
+                    "bcftools": 1.22
+                },
+                "BCFTOOLS_STATS": {
+                    "bcftools": 1.22
+                },
+                "BEDTOOLS_MERGE": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SORT": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SPLIT": {
+                    "bedtools": "2.31.1"
+                },
+                "DEEPVARIANT_RUNDEEPVARIANT": {
+                    "deepvariant": null
+                },
+                "DEEPVARIANT_VCFSTATSREPORT": {
+                    "deepvariant": null
+                },
+                "GAWK_EXTRACT_REGIONS": {
+                    "gawk": "5.3.1"
+                },
+                "GLNEXUS": {
+                    "glnexus": "1.4.3"
+                },
+                "GUNZIP_FASTA": {
+                    "gunzip": 1.13
+                },
+                "MINIMAP2_ALIGN": {
+                    "minimap2": "2.29-r1283"
+                },
+                "MINIMAP2_INDEX": {
+                    "minimap2": "2.29-r1283"
+                },
+                "RELATE_INFER": {
+                    "somalier": "0.2.18"
+                },
+                "RELATE_RELATE": {
+                    "somalier": "0.2.18"
+                },
+                "SAMPLESHEET_PED": {
+                    "create_pedigree_file": 1.0,
+                    "python": "3.8.3"
+                },
+                "SAMTOOLS_FAIDX": {
+                    "samtools": "1.23.1"
+                },
+                "SAMTOOLS_IMPORT": {
+                    "samtools": "1.23.1"
+                },
+                "SAMTOOLS_MERGE": {
+                    "samtools": "1.23.1"
+                },
+                "SOMALIER_EXTRACT": {
+                    "somalier": "0.2.18"
+                },
+                "SPLITUBAM": {
+                    "splitubam": "0.1.1"
+                },
+                "UNTAR_VEP_CACHE": {
+                    "untar": 1.34
+                },
+                "VCFEXPRESS": {
+                    "vcfexpress": "0.3.4"
+                },
+                "Workflow": {
+                    "genomic-medicine-sweden/nallo": "v0.13.0dev"
+                }
+            },
+            [
+                "aligned_reads",
+                "aligned_reads/HG002_Revio",
+                "aligned_reads/HG002_Revio/HG002_Revio.bai",
+                "aligned_reads/HG002_Revio/HG002_Revio.bam",
+                "multiqc",
+                "multiqc/multiqc_data",
+                "multiqc/multiqc_data/.stub",
+                "multiqc/multiqc_plots",
+                "multiqc/multiqc_plots/.stub",
+                "multiqc/multiqc_report.html",
+                "pipeline_info",
+                "pipeline_info/nallo_software_mqc_versions.yml",
+                "qc",
+                "qc/bcftools_stats",
+                "qc/bcftools_stats/HG002_Revio",
+                "qc/bcftools_stats/HG002_Revio/HG002_Revio.bcftools_stats.txt",
+                "qc/deepvariant_vcfstatsreport",
+                "qc/deepvariant_vcfstatsreport/HG002_Revio",
+                "qc/deepvariant_vcfstatsreport/HG002_Revio/HG002_Revio.visual_report.html",
+                "qc/somalier",
+                "qc/somalier/relate",
+                "qc/somalier/relate/test",
+                "qc/somalier/relate/test/test.html",
+                "qc/somalier/relate/test/test.pairs.tsv",
+                "qc/somalier/relate/test/test.samples.tsv",
+                "snvs",
+                "snvs/family",
+                "snvs/family/FAM",
+                "snvs/family/FAM/FAM_snvs.vcf.gz",
+                "snvs/family/FAM/FAM_snvs.vcf.gz.tbi",
+                "snvs/sample",
+                "snvs/sample/HG002_Revio",
+                "snvs/sample/HG002_Revio/HG002_Revio_deepvariant_snvs.vcf.gz",
+                "snvs/sample/HG002_Revio/HG002_Revio_deepvariant_snvs.vcf.gz.tbi"
+            ]
+        ],
+        "timestamp": "2026-07-06T16:48:48.156048",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    },
+    "Test mitochondrial calling runs by default": {
+        "content": [
+            40,
+            {
+                "BCFTOOLS_CONCAT": {
+                    "bcftools": 1.21
+                },
+                "BCFTOOLS_MERGE": {
+                    "bcftools": 1.22
+                },
+                "BCFTOOLS_NORM_MULTISAMPLE": {
+                    "bcftools": 1.22
+                },
+                "BCFTOOLS_NORM_SINGLESAMPLE": {
+                    "bcftools": 1.22
+                },
+                "BCFTOOLS_SORT": {
+                    "bcftools": 1.22
+                },
+                "BCFTOOLS_STATS": {
+                    "bcftools": 1.22
+                },
+                "BCFTOOLS_VIEW_MITO": {
+                    "bcftools": 1.22
+                },
+                "BEDTOOLS_MERGE": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SORT": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SPLIT": {
+                    "bedtools": "2.31.1"
+                },
+                "DEEPVARIANT_RUNDEEPVARIANT": {
+                    "deepvariant": null
+                },
+                "DEEPVARIANT_VCFSTATSREPORT": {
+                    "deepvariant": null
+                },
+                "GAWK_EXTRACT_REGIONS": {
+                    "gawk": "5.3.1"
+                },
+                "GLNEXUS": {
+                    "glnexus": "1.4.3"
+                },
+                "GUNZIP_FASTA": {
+                    "gunzip": 1.13
+                },
+                "MINIMAP2_ALIGN": {
+                    "minimap2": "2.29-r1283"
+                },
+                "MINIMAP2_INDEX": {
+                    "minimap2": "2.29-r1283"
+                },
+                "MITORSAW_HAPLOTYPE": {
+                    "mitorsaw": "0.2.9-0dc8e58"
+                },
+                "RELATE_INFER": {
+                    "somalier": "0.2.18"
+                },
+                "RELATE_RELATE": {
+                    "somalier": "0.2.18"
+                },
+                "SAMPLESHEET_PED": {
+                    "create_pedigree_file": 1.0,
+                    "python": "3.8.3"
+                },
+                "SAMTOOLS_FAIDX": {
+                    "samtools": "1.23.1"
+                },
+                "SAMTOOLS_IMPORT": {
+                    "samtools": "1.23.1"
+                },
+                "SAMTOOLS_MERGE": {
+                    "samtools": "1.23.1"
+                },
+                "SOMALIER_EXTRACT": {
+                    "somalier": "0.2.18"
+                },
+                "SPLITUBAM": {
+                    "splitubam": "0.1.1"
+                },
+                "UNTAR_VEP_CACHE": {
+                    "untar": 1.34
+                },
+                "VCFEXPRESS": {
+                    "vcfexpress": "0.3.4"
+                },
+                "Workflow": {
+                    "genomic-medicine-sweden/nallo": "v0.13.0dev"
+                }
+            },
+            [
+                "aligned_reads",
+                "aligned_reads/HG002_Revio",
+                "aligned_reads/HG002_Revio/HG002_Revio.bai",
+                "aligned_reads/HG002_Revio/HG002_Revio.bam",
+                "multiqc",
+                "multiqc/multiqc_data",
+                "multiqc/multiqc_data/.stub",
+                "multiqc/multiqc_plots",
+                "multiqc/multiqc_plots/.stub",
+                "multiqc/multiqc_report.html",
+                "pipeline_info",
+                "pipeline_info/nallo_software_mqc_versions.yml",
+                "qc",
+                "qc/bcftools_stats",
+                "qc/bcftools_stats/HG002_Revio",
+                "qc/bcftools_stats/HG002_Revio/HG002_Revio.bcftools_stats.txt",
+                "qc/deepvariant_vcfstatsreport",
+                "qc/deepvariant_vcfstatsreport/HG002_Revio",
+                "qc/deepvariant_vcfstatsreport/HG002_Revio/HG002_Revio.visual_report.html",
+                "qc/somalier",
+                "qc/somalier/relate",
+                "qc/somalier/relate/test",
+                "qc/somalier/relate/test/test.html",
+                "qc/somalier/relate/test/test.pairs.tsv",
+                "qc/somalier/relate/test/test.samples.tsv",
+                "snvs",
+                "snvs/family",
+                "snvs/family/FAM",
+                "snvs/family/FAM/FAM_snvs.vcf.gz",
+                "snvs/family/FAM/FAM_snvs.vcf.gz.tbi",
+                "snvs/sample",
+                "snvs/sample/HG002_Revio",
+                "snvs/sample/HG002_Revio/HG002_Revio_deepvariant_snvs.vcf.gz",
+                "snvs/sample/HG002_Revio/HG002_Revio_deepvariant_snvs.vcf.gz.tbi"
+            ]
+        ],
+        "timestamp": "2026-07-06T16:47:20.678927",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    }
+}

--- a/tests/stub_skip_snv_annotation.nf.test
+++ b/tests/stub_skip_snv_annotation.nf.test
@@ -29,6 +29,7 @@ nextflow_pipeline {
                 skip_methylation_calling     = true
                 skip_methylation_annotation  = true
                 skip_prepare_gens_input      = true
+                skip_mitochondrial_calling   = true
             }
         }
 
@@ -73,6 +74,7 @@ nextflow_pipeline {
                 skip_methylation_calling     = true
                 skip_methylation_annotation  = true
                 skip_prepare_gens_input      = true
+                skip_mitochondrial_calling   = true
                 skip_genome_assembly         = true
             }
         }

--- a/tests/stub_skip_snv_annotation.nf.test.snap
+++ b/tests/stub_skip_snv_annotation.nf.test.snap
@@ -54,10 +54,10 @@
                     "bgzip": 1.21
                 },
                 "DEEPVARIANT_RUNDEEPVARIANT": {
-                    "deepvariant": null
+                    "deepvariant": "1.10.0"
                 },
                 "DEEPVARIANT_VCFSTATSREPORT": {
-                    "deepvariant": null
+                    "deepvariant": "1.10.0"
                 },
                 "ENSEMBLVEP_FILTERVEP": {
                     "ensemblvep": 115.2,
@@ -270,10 +270,10 @@
                     "bedtools": "2.31.1"
                 },
                 "DEEPVARIANT_RUNDEEPVARIANT": {
-                    "deepvariant": null
+                    "deepvariant": "1.10.0"
                 },
                 "DEEPVARIANT_VCFSTATSREPORT": {
-                    "deepvariant": null
+                    "deepvariant": "1.10.0"
                 },
                 "GAWK_EXTRACT_REGIONS": {
                     "gawk": "5.3.1"

--- a/tests/stub_skip_snv_annotation.nf.test.snap
+++ b/tests/stub_skip_snv_annotation.nf.test.snap
@@ -1,13 +1,10 @@
 {
     "Test Chromograph works without SNV annotation": {
         "content": [
-            77,
+            71,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
-                },
-                "BCFTOOLS_MERGE": {
-                    "bcftools": 1.22
                 },
                 "BCFTOOLS_NORM_MULTISAMPLE": {
                     "bcftools": 1.22
@@ -28,9 +25,6 @@
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW": {
-                    "bcftools": 1.22
-                },
-                "BCFTOOLS_VIEW_MITO": {
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_SV": {
@@ -60,10 +54,10 @@
                     "bgzip": 1.21
                 },
                 "DEEPVARIANT_RUNDEEPVARIANT": {
-                    "deepvariant": "1.10.0"
+                    "deepvariant": null
                 },
                 "DEEPVARIANT_VCFSTATSREPORT": {
-                    "deepvariant": "1.10.0"
+                    "deepvariant": null
                 },
                 "ENSEMBLVEP_FILTERVEP": {
                     "ensemblvep": 115.2,
@@ -90,9 +84,6 @@
                 },
                 "MINIMAP2_INDEX": {
                     "minimap2": "2.29-r1283"
-                },
-                "MITORSAW_HAPLOTYPE": {
-                    "mitorsaw": "0.2.9-0dc8e58"
                 },
                 "RELATE_INFER": {
                     "somalier": "0.2.18"
@@ -244,21 +235,18 @@
                 "visualization_tracks/HG002_Revio/HG002_Revio_hificnv.maf.bw"
             ]
         ],
-        "timestamp": "2026-06-01T09:52:39.499675257",
+        "timestamp": "2026-07-05T20:13:52.762869",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.03.4"
+            "nextflow": "26.04.4"
         }
     },
     "Test Peddy without annotation": {
         "content": [
-            43,
+            37,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
-                },
-                "BCFTOOLS_MERGE": {
-                    "bcftools": 1.22
                 },
                 "BCFTOOLS_NORM_MULTISAMPLE": {
                     "bcftools": 1.22
@@ -272,9 +260,6 @@
                 "BCFTOOLS_STATS": {
                     "bcftools": 1.22
                 },
-                "BCFTOOLS_VIEW_MITO": {
-                    "bcftools": 1.22
-                },
                 "BEDTOOLS_MERGE": {
                     "bedtools": "2.31.1"
                 },
@@ -285,10 +270,10 @@
                     "bedtools": "2.31.1"
                 },
                 "DEEPVARIANT_RUNDEEPVARIANT": {
-                    "deepvariant": "1.10.0"
+                    "deepvariant": null
                 },
                 "DEEPVARIANT_VCFSTATSREPORT": {
-                    "deepvariant": "1.10.0"
+                    "deepvariant": null
                 },
                 "GAWK_EXTRACT_REGIONS": {
                     "gawk": "5.3.1"
@@ -304,9 +289,6 @@
                 },
                 "MINIMAP2_INDEX": {
                     "minimap2": "2.29-r1283"
-                },
-                "MITORSAW_HAPLOTYPE": {
-                    "mitorsaw": "0.2.9-0dc8e58"
                 },
                 "PEDDY": {
                     "peddy": "0.4.8"
@@ -395,10 +377,10 @@
                 "snvs/sample/HG002_Revio/HG002_Revio_deepvariant_snvs.vcf.gz.tbi"
             ]
         ],
-        "timestamp": "2026-06-01T09:53:06.242525686",
+        "timestamp": "2026-07-05T20:15:13.096959",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.03.4"
+            "nextflow": "26.04.4"
         }
     }
 }

--- a/workflows/nallo.nf
+++ b/workflows/nallo.nf
@@ -643,7 +643,7 @@ workflow NALLO {
             .join(family_snv_index, failOnMismatch: true, failOnDuplicate: true)
             .filter { meta, _vcf, _tbi -> meta.genome == "nuclear" }
             .map { meta, vcf, tbi ->
-                def new_meta = [id: meta.family_id, num_intervals: meta.num_intervals - 1]
+                def new_meta = [id: meta.family_id, num_intervals: val_skip_mitochondrial_calling ? meta.num_intervals : meta.num_intervals - 1]
                 [groupKey(new_meta, new_meta.num_intervals), vcf, tbi]
             }
             .groupTuple()
@@ -701,7 +701,7 @@ workflow NALLO {
         // Add +1 to the num_intervals of nuclear channel to account for mitochondrial region
         ch_snv_vcf_tbi_nuclear_for_annotation = BCFTOOLS_VIEW_PHASING.out.vcf
             .join(BCFTOOLS_VIEW_PHASING.out.tbi, failOnMismatch: true, failOnDuplicate: true)
-            .map { meta, vcf, tbi -> [meta + [num_intervals: meta.num_intervals + 1], vcf, tbi] }
+            .map { meta, vcf, tbi -> [meta + [num_intervals: val_skip_mitochondrial_calling ? meta.num_intervals : meta.num_intervals + 1], vcf, tbi] }
 
         ch_snv_vcf_tbi_mitochondrial_for_annotation = ch_snvs_per_family_unannotated_vcf_tbi
             .filter { meta, _vcf, _tbi -> meta.genome == "mitochondrial" }

--- a/workflows/nallo.nf
+++ b/workflows/nallo.nf
@@ -505,7 +505,8 @@ workflow NALLO {
         def variants_to_merge_per_family = CALL_SNVS.out.gvcf
             .join(CALL_SNVS.out.gvcf_index, failOnMismatch: true, failOnDuplicate: true)
             .map { meta, gvcf, index ->
-                [[id: meta.region.name, family_id: meta.family_id, genome: meta.genome, num_intervals: meta.num_intervals + 1, caller: val_snv_caller], gvcf, index]
+                def num_intervals = val_skip_mitochondrial_calling ? meta.num_intervals : meta.num_intervals + 1
+                [[id: meta.region.name, family_id: meta.family_id, genome: meta.genome, num_intervals: num_intervals, caller: val_snv_caller], gvcf, index]
             }
             .mix(ch_mitochondrial.vcf
                     .join(ch_mitochondrial.index, failOnMismatch: true, failOnDuplicate: true)

--- a/workflows/nallo.nf
+++ b/workflows/nallo.nf
@@ -158,6 +158,7 @@ workflow NALLO {
     val_skip_qc
     val_skip_rank_variants
     val_skip_repeat_annotation
+    val_skip_mitochondrial_calling
     val_skip_sambamba_depth
     val_skip_sex_check
     val_skip_snv_annotation
@@ -447,28 +448,32 @@ workflow NALLO {
         ch_mitochondrial_bed = SCATTER_GENOME.out.bed_mitochondrial_intervals
             .map { meta, bed, _num_intervals -> [meta, bed] }
 
-        CALL_MITOCHONDRIAL_VARIANTS(
-            ch_bam_bai,
-            ch_fasta,
-            ch_fai,
-            ch_par,
-            ch_mitochondrial_bed,
-            val_mitochondrial_caller,
-        )
-
-        /*
-         * The meta.caller is needed for GVCF_GLNEXUS_NORM_VARIANTS workflow to process the VCFs differently.
-         * the number of intervals is used in groupKey downstream, num_intervals should be the same in the nuclear and mitochondrial channels.
-         */
         def ch_num_intervals = ch_bed_intervals.map { _meta, _bed, num_intervals -> num_intervals }.first()
 
-        ch_mitochondrial = CALL_MITOCHONDRIAL_VARIANTS.out.mitochondrial_snv_vcf
-            .join(CALL_MITOCHONDRIAL_VARIANTS.out.mitochondrial_snv_tbi, failOnMismatch: true, failOnDuplicate: true)
-            .combine(ch_num_intervals)
-            .multiMap { meta, vcf, tbi, num_intervals ->
-                vcf: [meta + [caller: val_mitochondrial_caller, genome: 'mitochondrial', num_intervals: num_intervals + 1], vcf]
-                index: [meta + [caller: val_mitochondrial_caller, genome: 'mitochondrial', num_intervals: num_intervals + 1], tbi]
-            }
+        if (!val_skip_mitochondrial_calling) {
+            CALL_MITOCHONDRIAL_VARIANTS(
+                ch_bam_bai,
+                ch_fasta,
+                ch_fai,
+                ch_par,
+                ch_mitochondrial_bed,
+                val_mitochondrial_caller,
+            )
+
+            /*
+             * The meta.caller is needed for GVCF_GLNEXUS_NORM_VARIANTS workflow to process the VCFs differently.
+             * the number of intervals is used in groupKey downstream, num_intervals should be the same in the nuclear and mitochondrial channels.
+             */
+            ch_mitochondrial = CALL_MITOCHONDRIAL_VARIANTS.out.mitochondrial_snv_vcf
+                .join(CALL_MITOCHONDRIAL_VARIANTS.out.mitochondrial_snv_tbi, failOnMismatch: true, failOnDuplicate: true)
+                .combine(ch_num_intervals)
+                .multiMap { meta, vcf, tbi, num_intervals ->
+                    vcf: [meta + [caller: val_mitochondrial_caller, genome: 'mitochondrial', num_intervals: num_intervals + 1], vcf]
+                    index: [meta + [caller: val_mitochondrial_caller, genome: 'mitochondrial', num_intervals: num_intervals + 1], tbi]
+                }
+        } else {
+            ch_mitochondrial = channel.empty().multiMap { vcf: it; index: it }
+        }
 
         // Combine the BED intervals with BAM/BAI files to create a region-bam-bai for each sample.
         // This uses the whole BAM files for each region instead of splitting them.

--- a/workflows/nallo.nf
+++ b/workflows/nallo.nf
@@ -472,7 +472,10 @@ workflow NALLO {
                     index: [meta + [caller: val_mitochondrial_caller, genome: 'mitochondrial', num_intervals: num_intervals + 1], tbi]
                 }
         } else {
-            ch_mitochondrial = channel.empty().multiMap { vcf: it; index: it }
+            ch_mitochondrial = channel.empty().multiMap { it ->
+                vcf: it
+                index: it
+            }
         }
 
         // Combine the BED intervals with BAM/BAI files to create a region-bam-bai for each sample.


### PR DESCRIPTION
## Description

Closes #1129

Adds a `--skip_call_mt_variants` parameter to allow skipping the mitochondrial variant calling subworkflow. The default is `false` (existing behaviour unchanged).

## Changes

- **`nextflow.config`**: new `skip_call_mt_variants = false` parameter
- **`nextflow_schema.json`**: schema entry for the new parameter
- **`workflows/nallo.nf`**: guard `CALL_MITOCHONDRIAL_VARIANTS` with `if (!val_skip_call_mt_variants)`; emit empty channels when skipped so downstream joins do not stall
- **`main.nf`**: wire `params.skip_call_mt_variants` through the workflow call chain