### PR TITLE
Fix: remove --ubam from QC_PHASING:CRAMINO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1056](https://github.com/genomic-medicine-sweden/nallo/pull/1056) - Fixed nf-test CI not passing the matrix Nextflow version to the setup action.
 - [#1079](https://github.com/genomic-medicine-sweden/nallo/pull/1079) - Fixed typo in tests for `call_methylation_methbat`
 - [#1142](https://github.com/genomic-medicine-sweden/nallo/pull/1142) - Fixed Sentieon-specific SNV filtering to use the configured `--snv_caller` parameter
+- [#1172](https://github.com/genomic-medicine-sweden/nallo/pull/1172) - Fixed `--ubam` being set for `QC_PHASING:CRAMINO`, suppressing alignment-dependent metrics including `read_identity`
 
 ### Parameters
 

--- a/conf/modules/qc_phasing.config
+++ b/conf/modules/qc_phasing.config
@@ -15,7 +15,6 @@ process {
                 '--karyotype',
                 '--phased',
                 "--arrow ${meta.id}_cramino_aligned_phased.arrow",
-                '--ubam'
             ].join(' ')
         }
         ext.prefix = { "${meta.id}_cramino_aligned_phased" }

--- a/tests/stub_sex_check.nf.test.snap
+++ b/tests/stub_sex_check.nf.test.snap
@@ -485,7 +485,7 @@
                 "visualization_tracks/HG004/HG004_pbcpgtools.hap2.bw"
             ]
         ],
-        "timestamp": "2026-07-05T19:53:44.033069",
+        "timestamp": "2026-07-06T16:11:07.378165",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"


### PR DESCRIPTION
## Summary

- Removes `--ubam` from `conf/modules/qc_phasing.config` for the `.*:QC_PHASING:CRAMINO` process
- `--ubam` suppresses alignment-dependent metrics including `read_identity`; the phased cramino call runs on the haplotagged BAM and should report these metrics
- `QC_ALIGNED_READS:CRAMINO` retains `--ubam` intentionally (read-level yield/N50 metrics independent of alignment quality)

Closes #1171

## Test plan

- [x] `stub_sex_check` passes (snap updated for Nextflow 26.04.4 upgrade, unrelated to this change)