### PR TITLE
Format all local subworkflows and modules with `nextflow lint -format -harshil-alignment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1169](https://github.com/genomic-medicine-sweden/nallo/pull/1169) - Updated nf-dev guidelines sync config
 - [#1178](https://github.com/genomic-medicine-sweden/nallo/pull/1178) - Updated dataset with unmasked reference and only ML and MM tags in the fastq test file
 - [#1181](https://github.com/genomic-medicine-sweden/nallo/pull/1181) - Updated minimum nextflow version to 26.04.4
+- [#1183](https://github.com/genomic-medicine-sweden/nallo/pull/1183) - Formatted all local subworkflows and modules with `nextflow lint -format -harshil-alignment`
 
 ### Removed
 

--- a/modules/local/create_pedigree_file/main.nf
+++ b/modules/local/create_pedigree_file/main.nf
@@ -19,7 +19,7 @@ process CREATE_PEDIGREE_FILE {
     task.ext.when == null || task.ext.when
 
     script:
-    def prefix  = task.ext.prefix ?: "${meta.id}"
+    def prefix = task.ext.prefix ?: "${meta.id}"
     def samples = (sample_metas.collect().size() > 1)
         ? sample_metas.sort { a, b ->
             // First sort on family_id, then on sample id

--- a/modules/local/sentieon/dnascope_longread/main.nf
+++ b/modules/local/sentieon/dnascope_longread/main.nf
@@ -7,22 +7,22 @@ process DNASCOPE_LONGREAD_CALL_SNVS {
     container "docker.io/sentieon/sentieon-cli:1.6.2-0"
 
     input:
-    tuple val(meta),  path(bam), path(bai), path(diploid_intervals_bed), path(haploid_intervals_bed)
+    tuple val(meta), path(bam), path(bai), path(diploid_intervals_bed), path(haploid_intervals_bed)
     tuple val(meta2), path(fasta)
     tuple val(meta3), path(fai)
     tuple val(meta4), path(model_bundle)
     val tech
 
     output:
-    tuple val(meta), path("${prefix}.vcf.gz")                                                                                                , emit: vcf
-    tuple val(meta), path("${prefix}.vcf.gz.tbi")                                                                                            , emit: vcf_tbi
-    tuple val(meta), path("${prefix}.g.vcf.gz")                                                                                              , emit: gvcf
-    tuple val(meta), path("${prefix}.g.vcf.gz.tbi")                                                                                          , emit: gvcf_tbi
-    tuple val("${task.process}"), val("sentieon-cli"), eval("sentieon-cli --version")                                       , topic: versions, emit: versions_sentieon_cli
+    tuple val(meta), path("${prefix}.vcf.gz"), emit: vcf
+    tuple val(meta), path("${prefix}.vcf.gz.tbi"), emit: vcf_tbi
+    tuple val(meta), path("${prefix}.g.vcf.gz"), emit: gvcf
+    tuple val(meta), path("${prefix}.g.vcf.gz.tbi"), emit: gvcf_tbi
+    tuple val("${task.process}"), val("sentieon-cli"), eval("sentieon-cli --version"), topic: versions, emit: versions_sentieon_cli
     tuple val("${task.process}"), val("sentieon"), eval("sentieon driver --version 2>&1 | sed -e 's/sentieon-genomics-//g'"), topic: versions, emit: versions_sentieon
-    tuple val("${task.process}"), val('bedtools'), eval("bedtools --version | sed -e 's/bedtools v//g'")                    , topic: versions, emit: versions_bedtools
-    tuple val("${task.process}"), val("samtools"), eval("samtools version | sed '1!d;s/.* //'")                             , topic: versions, emit: versions_samtools
-    tuple val("${task.process}"), val("bcftools"), eval("bcftools --version | sed '1!d; s/^.*bcftools //'")                 , topic: versions, emit: versions_bcftools
+    tuple val("${task.process}"), val('bedtools'), eval("bedtools --version | sed -e 's/bedtools v//g'"), topic: versions, emit: versions_bedtools
+    tuple val("${task.process}"), val("samtools"), eval("samtools version | sed '1!d;s/.* //'"), topic: versions, emit: versions_samtools
+    tuple val("${task.process}"), val("bcftools"), eval("bcftools --version | sed '1!d; s/^.*bcftools //'"), topic: versions, emit: versions_bcftools
 
     script:
     prefix = task.ext.prefix ?: "${meta.id}"

--- a/subworkflows/local/align_assemblies/main.nf
+++ b/subworkflows/local/align_assemblies/main.nf
@@ -56,8 +56,8 @@ workflow ALIGN_ASSEMBLIES {
     }
 
     emit:
-    bam  = SAMTOOLS_MERGE.out.bam                                    // channel: [ val(meta), path(bam) ]
-    bai  = SAMTOOLS_MERGE.out.index                                  // channel: [ val(meta), path(bai) ]
+    bam  = SAMTOOLS_MERGE.out.bam // channel: [ val(meta), path(bam) ]
+    bai  = SAMTOOLS_MERGE.out.index // channel: [ val(meta), path(bai) ]
     cram = cram_output ? SAMTOOLS_CONVERT.out.cram : channel.empty() // channel: [ val(meta), path(cram) ]
     crai = cram_output ? SAMTOOLS_CONVERT.out.crai : channel.empty() // channel: [ val(meta), path(crai) ]
 }

--- a/subworkflows/local/annotate_cadd/main.nf
+++ b/subworkflows/local/annotate_cadd/main.nf
@@ -12,11 +12,11 @@ include { TABIX_TABIX as TABIX_CADD            } from '../../../modules/nf-core/
 
 workflow ANNOTATE_CADD {
     take:
-    ch_fai                   // channel: [mandatory] [ val(meta), path(fai) ]
-    ch_vcf                   // channel: [mandatory] [ val(meta), path(vcfs) ]
-    ch_index                 // channel: [optional]  [ val(meta), path(tbis) ]
-    ch_header                // channel: [mandatory] [ val(meta), path(txt) ]
-    ch_cadd_resources        // channel: [mandatory] [ val(meta), path(dir) ]
+    ch_fai // channel: [mandatory] [ val(meta), path(fai) ]
+    ch_vcf // channel: [mandatory] [ val(meta), path(vcfs) ]
+    ch_index // channel: [optional]  [ val(meta), path(tbis) ]
+    ch_header // channel: [mandatory] [ val(meta), path(txt) ]
+    ch_cadd_resources // channel: [mandatory] [ val(meta), path(dir) ]
     ch_cadd_prescored_indels // channel: [mandatory] [ val(meta), path(dir) ]
 
     main:
@@ -38,7 +38,7 @@ workflow ANNOTATE_CADD {
         .combine(REFERENCE_TO_CADD_CHRNAMES.out.output.map { _meta, txt -> txt })
 
     RENAME_CHRNAMES(
-        ch_rename_chrnames_in,
+        ch_rename_chrnames_in
     )
 
     BCFTOOLS_VIEW(

--- a/subworkflows/local/annotate_consequence_pli/main.nf
+++ b/subworkflows/local/annotate_consequence_pli/main.nf
@@ -7,7 +7,7 @@ include { CUSTOM_ADDMOSTSEVEREPLI         } from '../../../modules/nf-core/custo
 include { TABIX_TABIX                     } from '../../../modules/nf-core/tabix/tabix/main'
 workflow ANNOTATE_CSQ_PLI {
     take:
-    ch_vcf                  // channel: [mandatory] [ val(meta), path(vcf) ]
+    ch_vcf // channel: [mandatory] [ val(meta), path(vcf) ]
     ch_variant_consequences // channel: [mandatory] [ val(meta), path(consequences) ]
 
     main:
@@ -19,5 +19,5 @@ workflow ANNOTATE_CSQ_PLI {
 
     emit:
     vcf = CUSTOM_ADDMOSTSEVEREPLI.out.vcf // channel: [ val(meta), path(vcf) ]
-    tbi = TABIX_TABIX.out.index           // channel: [ val(meta), path(tbi) ]
+    tbi = TABIX_TABIX.out.index // channel: [ val(meta), path(tbi) ]
 }

--- a/subworkflows/local/annotate_paralogs/main.nf
+++ b/subworkflows/local/annotate_paralogs/main.nf
@@ -2,7 +2,7 @@ include { PARAPHRASE } from '../../../modules/nf-core/paraphrase/main'
 
 workflow ANNOTATE_PARALOGS {
     take:
-    ch_json                  // channel: [ val(meta), path(json) ]
+    ch_json // channel: [ val(meta), path(json) ]
     paraphrase_output_format // string: Output format for paraphrase (json or tsv)
     ch_paraphrase_rules_yaml // channel: [ val(meta), path(yaml) ]
 
@@ -14,7 +14,7 @@ workflow ANNOTATE_PARALOGS {
      * The order of JSON files and sample names must remain aligned, since paraphrase assigns sample names to JSONs by positional order.
      */
     ch_paraphase_jsons_per_family = ch_json
-        .map { meta, json -> [ [ 'id': meta.family_id ], json, meta.id ] }
+        .map { meta, json -> [['id': meta.family_id], json, meta.id] }
         .groupTuple()
 
     PARAPHRASE(

--- a/subworkflows/local/annotate_repeat_expansions/main.nf
+++ b/subworkflows/local/annotate_repeat_expansions/main.nf
@@ -2,11 +2,11 @@ include { STRANGER     } from '../../../modules/nf-core/stranger/'
 include { STRDROP_CALL } from '../../../modules/nf-core/strdrop/call/main'
 workflow ANNOTATE_REPEAT_EXPANSIONS {
     take:
-    vcf                       // channel: [ val(meta), path(vcf) ]
+    vcf // channel: [ val(meta), path(vcf) ]
     strdrop_training_set_json // channel: [ val(meta), path(json) ]
     strdrop_training_set_vcfs // channel: [ val(meta), [ path(vcf) ] ]
-    stranger_variant_catalog  // channel: [ val(meta), path(json) ]
-    run_strdrop               //    bool: should strdrop be run before stranger
+    stranger_variant_catalog // channel: [ val(meta), path(json) ]
+    run_strdrop //    bool: should strdrop be run before stranger
 
     main:
 

--- a/subworkflows/local/annotate_snvs/main.nf
+++ b/subworkflows/local/annotate_snvs/main.nf
@@ -5,19 +5,19 @@ include { ENSEMBLVEP_VEP as ENSEMBLVEP_SNV } from '../../../modules/nf-core/ense
 
 workflow ANNOTATE_SNVS {
     take:
-    ch_vcf                   // channel: [mandatory] [ val(meta), path(vcf) ]
-    ch_echtvar_databases     // channel:  [optional] [ val(meta), path(db) ]
-    ch_fasta                 // channel: [mandatory] [ val(meta), path(fasta) ]
-    ch_fai                   // channel: [mandatory] [ val(meta), path(fai) ]
-    ch_vep_cache             // channel: [mandatory] [ val(meta), path(cache) ]
-    val_vep_cache_version    //  string: [mandatory] default: 110
-    ch_vep_extra_files       // channel: [mandatory] [ path(files) ]
-    annotate_cadd            //    bool: [mandatory] should CADD be used to annotate indels
-    annotate_echtvar         //    bool: [mandatory] should echtvar be used to annotate variants
-    ch_cadd_header           // channel:  [optional] [ path(txt) ]
-    ch_cadd_resources        // channel:  [optional] [ val(meta), path(annotation) ]
+    ch_vcf // channel: [mandatory] [ val(meta), path(vcf) ]
+    ch_echtvar_databases // channel:  [optional] [ val(meta), path(db) ]
+    ch_fasta // channel: [mandatory] [ val(meta), path(fasta) ]
+    ch_fai // channel: [mandatory] [ val(meta), path(fai) ]
+    ch_vep_cache // channel: [mandatory] [ val(meta), path(cache) ]
+    val_vep_cache_version //  string: [mandatory] default: 110
+    ch_vep_extra_files // channel: [mandatory] [ path(files) ]
+    annotate_cadd //    bool: [mandatory] should CADD be used to annotate indels
+    annotate_echtvar //    bool: [mandatory] should echtvar be used to annotate variants
+    ch_cadd_header // channel:  [optional] [ path(txt) ]
+    ch_cadd_resources // channel:  [optional] [ val(meta), path(annotation) ]
     ch_cadd_prescored_indels // channel:  [optional] [ val(meta), path(prescored) ]
-    pre_vep_filter           //    bool: [mandatory] should filtering be done before annotating with CADD and VEP
+    pre_vep_filter //    bool: [mandatory] should filtering be done before annotating with CADD and VEP
 
     main:
     // Annotate with chosen databases
@@ -25,14 +25,13 @@ workflow ANNOTATE_SNVS {
         ECHTVAR_ANNO(
             ch_vcf,
             ch_echtvar_databases,
-            'bcf.gz'
+            'bcf.gz',
         )
     }
 
     // Allows for filtering before annotating with VEP
     if (pre_vep_filter) {
-        ch_bcftools_view_input = (annotate_echtvar ? ECHTVAR_ANNO.out.vcf : ch_vcf)
-            .map { meta, vcf -> [meta, vcf, []] }
+        ch_bcftools_view_input = (annotate_echtvar ? ECHTVAR_ANNO.out.vcf : ch_vcf).map { meta, vcf -> [meta, vcf, []] }
 
         BCFTOOLS_VIEW(
             ch_bcftools_view_input,
@@ -57,8 +56,7 @@ workflow ANNOTATE_SNVS {
         )
     }
 
-    ch_vep_in = (annotate_cadd ? ANNOTATE_CADD.out.vcf : pre_vep_filter ? BCFTOOLS_VIEW.out.vcf : annotate_echtvar ? ECHTVAR_ANNO.out.vcf : ch_vcf)
-        .map { meta, vcf -> [meta, vcf, []] }
+    ch_vep_in = (annotate_cadd ? ANNOTATE_CADD.out.vcf : pre_vep_filter ? BCFTOOLS_VIEW.out.vcf : annotate_echtvar ? ECHTVAR_ANNO.out.vcf : ch_vcf).map { meta, vcf -> [meta, vcf, []] }
 
     // Always annotate with VEP
     ENSEMBLVEP_SNV(

--- a/subworkflows/local/annotate_svs/main.nf
+++ b/subworkflows/local/annotate_svs/main.nf
@@ -3,22 +3,21 @@ include { ENSEMBLVEP_VEP as ENSEMBLVEP_SV } from '../../../modules/nf-core/ensem
 
 workflow ANNOTATE_SVS {
     take:
-    ch_vcf                // channel: [mandatory] [ val(meta), path(vcf) ]
-    ch_fasta              // channel: [mandatory] [ val(meta), path(fasta) ]
-    ch_sv_dbs             // channel: [mandatory] [ val(meta), path(csv) ]
-    ch_vep_cache          // channel: [mandatory] [ val(meta), path(cache) ]
+    ch_vcf // channel: [mandatory] [ val(meta), path(vcf) ]
+    ch_fasta // channel: [mandatory] [ val(meta), path(fasta) ]
+    ch_sv_dbs // channel: [mandatory] [ val(meta), path(csv) ]
+    ch_vep_cache // channel: [mandatory] [ val(meta), path(cache) ]
     val_vep_cache_version // string: [mandatory] default: 110
-    ch_vep_extra_files    // channel: [mandatory] [ path(files) ]
+    ch_vep_extra_files // channel: [mandatory] [ path(files) ]
 
     main:
-    ch_svdb_in = ch_sv_dbs
-        .multiMap { filename, in_freq_info_key, in_allele_count_info_key, out_freq_info_key, out_allele_count_info_key ->
-            vcf_dbs: filename
-            in_frqs: in_freq_info_key
-            in_occs: in_allele_count_info_key
-            out_frqs: out_freq_info_key
-            out_occs: out_allele_count_info_key
-        }
+    ch_svdb_in = ch_sv_dbs.multiMap { filename, in_freq_info_key, in_allele_count_info_key, out_freq_info_key, out_allele_count_info_key ->
+        vcf_dbs: filename
+        in_frqs: in_freq_info_key
+        in_occs: in_allele_count_info_key
+        out_frqs: out_freq_info_key
+        out_occs: out_allele_count_info_key
+    }
 
     // Annotate with SVDB VCF "databases"
     SVDB_QUERY(

--- a/subworkflows/local/bam_infer_sex/main.nf
+++ b/subworkflows/local/bam_infer_sex/main.nf
@@ -4,11 +4,11 @@ include { SOMALIER_RELATE as RELATE_RELATE } from '../../../modules/nf-core/soma
 
 workflow BAM_INFER_SEX {
     take:
-    ch_bam_bai        // channel: [ val(meta), path(bam), path(bai) ]
-    ch_fasta          // channel: [ val(meta), path(fasta) ]
-    ch_fai            // channel: [ val(meta), path(fai) ]
+    ch_bam_bai // channel: [ val(meta), path(bam), path(bai) ]
+    ch_fasta // channel: [ val(meta), path(fasta) ]
+    ch_fai // channel: [ val(meta), path(fai) ]
     ch_somalier_sites // channel: [ val(meta), path(somalier_sites_vcf) ]
-    ch_ped            // channel: [ val(meta), path(ped) ]
+    ch_ped // channel: [ val(meta), path(ped) ]
 
     main:
     // Extract sites
@@ -20,7 +20,7 @@ workflow BAM_INFER_SEX {
     )
 
     ch_relate_infer_in = SOMALIER_EXTRACT.out.extract
-        .combine( ch_ped.map { _meta, ped -> ped } )
+        .combine(ch_ped.map { _meta, ped -> ped })
         .filter { meta, _extract, _ped -> meta.sex == 0 }
 
     // 1. Run somalier relate on one sample at a time to infer sex
@@ -30,25 +30,23 @@ workflow BAM_INFER_SEX {
         .map { _meta, tsv -> tsv }
         .splitCsv(header: true, sep: '\t')
 
-    ch_somalier_sex = ch_somalier_tsv
-        .map { it ->
-            // Hard error if sex could not be inferred for unknown sex samples
-            assert !(it.original_pedigree_sex == "unknown" && (it.sex.toInteger() != 1 && it.sex.toInteger() != 2)) : "ERROR: Sex could not be automatically inferred for ${it.sample_id}. Please inspect manually and set sex in the samplesheet."
+    ch_somalier_sex = ch_somalier_tsv.map { it ->
+        // Hard error if sex could not be inferred for unknown sex samples
+        assert !(it.original_pedigree_sex == "unknown" && (it.sex.toInteger() != 1 && it.sex.toInteger() != 2)) : "ERROR: Sex could not be automatically inferred for ${it.sample_id}. Please inspect manually and set sex in the samplesheet."
 
-            [ it.sample_id, it ]
-        }
+        [it.sample_id, it]
+    }
 
     // Branch on samples with known/unknown sex
-    ch_samples = ch_bam_bai
-        .branch { meta, _bam, _bai ->
-            unknown_sex: meta.sex == 0
-            known_sex: meta.sex != 0
-        }
+    ch_samples = ch_bam_bai.branch { meta, _bam, _bai ->
+        unknown_sex: meta.sex == 0
+        known_sex: meta.sex != 0
+    }
 
     // Update sex with sex from somalier for samples with unknown sex
     ch_updated_sex = ch_samples.unknown_sex
-        .map { meta, bam, bai -> [ meta.id, meta, bam, bai ] }
-        .join( ch_somalier_sex, failOnMismatch:true, failOnDuplicate:true )
+        .map { meta, bam, bai -> [meta.id, meta, bam, bai] }
+        .join(ch_somalier_sex, failOnMismatch: true, failOnDuplicate: true)
         .map { _id, meta, bam, bai, somalier ->
             def updated_sex = (meta.sex == 0 ? somalier.sex.toInteger() : meta.sex)
             [meta + [sex: updated_sex], bam, bai]
@@ -59,17 +57,17 @@ workflow BAM_INFER_SEX {
 
     // 2. Run relate on all samples at once to check relatedness
     ch_relate_relate_in = SOMALIER_EXTRACT.out.extract
-        .map { meta, extract -> [ [ id: meta.project ], extract ] }
+        .map { meta, extract -> [[id: meta.project], extract] }
         .groupTuple()
-        .join( ch_ped, failOnMismatch:true, failOnDuplicate:true )
+        .join(ch_ped, failOnMismatch: true, failOnDuplicate: true)
 
     RELATE_RELATE(ch_relate_relate_in, [])
 
     emit:
-    bam              = ch_updated_sex.map { meta, bam, _bai -> [ meta, bam ] } // channel: [ val(meta), path(bam) ]
-    bai              = ch_updated_sex.map { meta, _bam, bai -> [ meta, bai ] } // channel: [ val(meta), path(bai) ]
-    bam_bai          = ch_updated_sex                                          // channel: [ val(meta), path(bam), path(bai) ]
-    somalier_html    = RELATE_RELATE.out.html                                  // channel: [ val(meta), path(html) ]
-    somalier_samples = RELATE_RELATE.out.samples_tsv                           // channel: [ val(meta), path(samples_tsv) ]
-    somalier_pairs   = RELATE_RELATE.out.pairs_tsv                             // channel: [ val(meta), path(pairs_tsv) ]
+    bam              = ch_updated_sex.map { meta, bam, _bai -> [meta, bam] } // channel: [ val(meta), path(bam) ]
+    bai              = ch_updated_sex.map { meta, _bam, bai -> [meta, bai] } // channel: [ val(meta), path(bai) ]
+    bam_bai          = ch_updated_sex // channel: [ val(meta), path(bam), path(bai) ]
+    somalier_html    = RELATE_RELATE.out.html // channel: [ val(meta), path(html) ]
+    somalier_samples = RELATE_RELATE.out.samples_tsv // channel: [ val(meta), path(samples_tsv) ]
+    somalier_pairs   = RELATE_RELATE.out.pairs_tsv // channel: [ val(meta), path(pairs_tsv) ]
 }

--- a/subworkflows/local/call_methylation_methbat/main.nf
+++ b/subworkflows/local/call_methylation_methbat/main.nf
@@ -27,15 +27,15 @@ workflow CALL_METHYLATION_METHBAT {
     )
 
     emit:
-    region_profile        = METHBAT_PROFILE.out.region_profile                      // channel: [ val(meta), path(tsv) ]
-    asm_bed               = METHBAT_PROFILE.out.asm_bed                             // channel: [ val(meta), path(bed) ]
-    pbcpg_combined_bigwig = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.combined_bigwig    // channel: [ val(meta), path(combined.bw) ]
-    pbcpg_hap1_bigwig     = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.hap1_bigwig        // channel: [ val(meta), path(hap1.bw) ]
-    pbcpg_hap2_bigwig     = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.hap2_bigwig        // channel: [ val(meta), path(hap2.bw) ]
-    pbcpg_combined_bed    = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.combined_bed       // channel: [ val(meta), path(combined.bed.gz) ]
+    region_profile        = METHBAT_PROFILE.out.region_profile // channel: [ val(meta), path(tsv) ]
+    asm_bed               = METHBAT_PROFILE.out.asm_bed // channel: [ val(meta), path(bed) ]
+    pbcpg_combined_bigwig = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.combined_bigwig // channel: [ val(meta), path(combined.bw) ]
+    pbcpg_hap1_bigwig     = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.hap1_bigwig // channel: [ val(meta), path(hap1.bw) ]
+    pbcpg_hap2_bigwig     = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.hap2_bigwig // channel: [ val(meta), path(hap2.bw) ]
+    pbcpg_combined_bed    = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.combined_bed // channel: [ val(meta), path(combined.bed.gz) ]
     pbcpg_combined_index  = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.combined_bed_index // channel: [ val(meta), path(combined.bed.gz.tbi) ]
-    pbcpg_hap1_bed        = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.hap1_bed           // channel: [ val(meta), path(hap1.bed.gz) ]
-    pbcpg_hap1_index      = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.hap1_bed_index     // channel: [ val(meta), path(hap1.bed.gz.tbi) ]
-    pbcpg_hap2_bed        = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.hap2_bed           // channel: [ val(meta), path(hap2.bed.gz) ]
-    pbcpg_hap2_index      = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.hap2_bed_index     // channel: [ val(meta), path(hap2.bed.gz.tbi) ]
+    pbcpg_hap1_bed        = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.hap1_bed // channel: [ val(meta), path(hap1.bed.gz) ]
+    pbcpg_hap1_index      = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.hap1_bed_index // channel: [ val(meta), path(hap1.bed.gz.tbi) ]
+    pbcpg_hap2_bed        = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.hap2_bed // channel: [ val(meta), path(hap2.bed.gz) ]
+    pbcpg_hap2_index      = PBCPGTOOLS_ALIGNEDBAMTOCPGSCORES.out.hap2_bed_index // channel: [ val(meta), path(hap2.bed.gz.tbi) ]
 }

--- a/subworkflows/local/call_methylation_modkit/main.nf
+++ b/subworkflows/local/call_methylation_modkit/main.nf
@@ -21,6 +21,7 @@ workflow CALL_METHYLATION_MODKIT {
         ch_bed,
     )
 
+    // Only convert files with content
     ch_bedmethyl_to_bigwig_in = MODKIT_PILEUP.out.bedgz
         .transpose()
         .tap { ch_bedmethyl }

--- a/subworkflows/local/call_methylation_modkit/main.nf
+++ b/subworkflows/local/call_methylation_modkit/main.nf
@@ -4,10 +4,10 @@ include { TABIX_TABIX              } from '../../../modules/nf-core/tabix/tabix/
 workflow CALL_METHYLATION_MODKIT {
     take:
     ch_bam_bai // channel: [ val(meta), bam, bai ]
-    ch_fasta   // channel: [ val(meta), fasta ]
-    ch_fai     // channel: [ val(meta), fai ]
-    ch_bed     // channel: [ val(meta), bed ]
-    modcodes   // String or List
+    ch_fasta // channel: [ val(meta), fasta ]
+    ch_fai // channel: [ val(meta), fai ]
+    ch_bed // channel: [ val(meta), bed ]
+    modcodes // String or List
 
     main:
     ch_fasta_fai = ch_fasta
@@ -24,7 +24,6 @@ workflow CALL_METHYLATION_MODKIT {
     ch_bedmethyl_to_bigwig_in = MODKIT_PILEUP.out.bedgz
         .transpose()
         .tap { ch_bedmethyl }
-        // Only convert files with content
         .filter { _meta, bed -> gzNotEmptyBySize(bed) }
 
     TABIX_TABIX(
@@ -38,13 +37,13 @@ workflow CALL_METHYLATION_MODKIT {
     )
 
     emit:
-    bed      = ch_bedmethyl                    // channel: [ val(meta), path(bed) ]
-    tbi      = TABIX_TABIX.out.index           // channel: [ val(meta), path(tbi) ]
-    bigwig   = MODKIT_BEDMETHYLTOBIGWIG.out.bw // channel: [ val(meta), path(bw) ]
+    bed    = ch_bedmethyl // channel: [ val(meta), path(bed) ]
+    tbi    = TABIX_TABIX.out.index // channel: [ val(meta), path(tbi) ]
+    bigwig = MODKIT_BEDMETHYLTOBIGWIG.out.bw // channel: [ val(meta), path(bw) ]
 }
 
 def gzNotEmptyBySize(file_path) {
-    File gzipFile = file_path.toFile()
+    def gzipFile: File = file_path.toFile()
     // When modkit produces an emty file, its size seems to be 168 bytes
     if (gzipFile.length() > 168) {
         return true

--- a/subworkflows/local/call_mitochondrial_variants/main.nf
+++ b/subworkflows/local/call_mitochondrial_variants/main.nf
@@ -8,12 +8,12 @@ include { MITORSAW_HAPLOTYPE                  } from '../../../modules/nf-core/m
 
 workflow CALL_MITOCHONDRIAL_VARIANTS {
     take:
-    ch_bam_bai            // channel: [val(meta), path(bam), path(bai)]
-    ch_fasta              // channel: [val(meta), path(fasta)]
-    ch_fai                // channel: [val(meta), path(fai)]
-    ch_par_bed            // channel: [val(meta), path(bed)]  – PAR regions (deepvariant)
-    ch_mitochondrial_bed  // channel: [val(meta), path(bed)]  – mitochondrial interval (deepvariant)
-    mitochondrial_caller  // string
+    ch_bam_bai // channel: [val(meta), path(bam), path(bai)]
+    ch_fasta // channel: [val(meta), path(fasta)]
+    ch_fai // channel: [val(meta), path(fai)]
+    ch_par_bed // channel: [val(meta), path(bed)]  – PAR regions (deepvariant)
+    ch_mitochondrial_bed // channel: [val(meta), path(bed)]  – mitochondrial interval (deepvariant)
+    mitochondrial_caller // string
 
     main:
     ch_fasta_fai = ch_fasta
@@ -33,7 +33,7 @@ workflow CALL_MITOCHONDRIAL_VARIANTS {
     }
     else if (mitochondrial_caller == "deepvariant") {
 
-    /*
+        /*
      * Add the mitochondrial BED to every sample, skip if BED is empty. We do not want to run Deepvariant with an empty bed.
      * The BED can be empty if there is no chrM region in the original BED processed in SCATTER_GENOME
      */
@@ -62,42 +62,39 @@ workflow CALL_MITOCHONDRIAL_VARIANTS {
      */
     if (mitochondrial_caller != "deepvariant") {
 
-        ch_mito_split_input = ch_vcf
-            .flatMap { meta, vcf ->
-                [[meta + [variant_type: "snv"], vcf, []], [meta + [variant_type: "sv"], vcf, []]]
-            }
+        ch_mito_split_input = ch_vcf.flatMap { meta, vcf ->
+            [[meta + [variant_type: "snv"], vcf, []], [meta + [variant_type: "sv"], vcf, []]]
+        }
 
         BCFTOOLS_VIEW_MITO(ch_mito_split_input, [], [], [])
 
-        ch_mito_vcf_split = BCFTOOLS_VIEW_MITO.out.vcf
-            .branch { meta, _vcf ->
-                snv: meta.variant_type == "snv"
-                sv: meta.variant_type == "sv"
-            }
+        ch_mito_vcf_split = BCFTOOLS_VIEW_MITO.out.vcf.branch { meta, _vcf ->
+            snv: meta.variant_type == "snv"
+            sv: meta.variant_type == "sv"
+        }
 
-        ch_mito_tbi_split = BCFTOOLS_VIEW_MITO.out.tbi
-            .branch { meta, _tbi ->
-                snv: meta.variant_type == "snv"
-                sv: meta.variant_type == "sv"
-            }
+        ch_mito_tbi_split = BCFTOOLS_VIEW_MITO.out.tbi.branch { meta, _tbi ->
+            snv: meta.variant_type == "snv"
+            sv: meta.variant_type == "sv"
+        }
 
         ch_snv_vcf = remove_variant_type_from_meta(ch_mito_vcf_split.snv)
         ch_snv_tbi = remove_variant_type_from_meta(ch_mito_tbi_split.snv)
-        ch_sv_vcf  = remove_variant_type_from_meta(ch_mito_vcf_split.sv)
-        ch_sv_tbi  = remove_variant_type_from_meta(ch_mito_tbi_split.sv)
-
-    } else {
+        ch_sv_vcf = remove_variant_type_from_meta(ch_mito_vcf_split.sv)
+        ch_sv_tbi = remove_variant_type_from_meta(ch_mito_tbi_split.sv)
+    }
+    else {
         ch_snv_vcf = ch_vcf
         ch_snv_tbi = ch_tbi
-        ch_sv_vcf  = channel.empty()
-        ch_sv_tbi  = channel.empty()
+        ch_sv_vcf = channel.empty()
+        ch_sv_tbi = channel.empty()
     }
 
     emit:
-    mitochondrial_snv_vcf = ch_snv_vcf  // channel: [val(meta), path(vcf)]
-    mitochondrial_snv_tbi = ch_snv_tbi  // channel: [val(meta), path(tbi)]
-    mitochondrial_sv_vcf  = ch_sv_vcf   // channel: [val(meta), path(vcf)]
-    mitochondrial_sv_tbi  = ch_sv_tbi   // channel: [val(meta), path(tbi)]
+    mitochondrial_snv_vcf = ch_snv_vcf // channel: [val(meta), path(vcf)]
+    mitochondrial_snv_tbi = ch_snv_tbi // channel: [val(meta), path(tbi)]
+    mitochondrial_sv_vcf  = ch_sv_vcf // channel: [val(meta), path(vcf)]
+    mitochondrial_sv_tbi  = ch_sv_tbi // channel: [val(meta), path(tbi)]
 }
 def remove_variant_type_from_meta(channel) {
     channel.map { meta, file -> [meta - meta.subMap('variant_type'), file] }

--- a/subworkflows/local/call_paralogs/main.nf
+++ b/subworkflows/local/call_paralogs/main.nf
@@ -7,9 +7,9 @@ include { SAMTOOLS_CONVERT  } from '../../../modules/nf-core/samtools/convert/ma
 
 workflow CALL_PARALOGS {
     take:
-    bam_bai     // channel: [ val(meta), bam, bai ]
-    fasta       // channel: [ val(meta), fasta ]
-    fai         // channel: [ val(meta), fai ]
+    bam_bai // channel: [ val(meta), bam, bai ]
+    fasta // channel: [ val(meta), fasta ]
+    fai // channel: [ val(meta), fai ]
     cram_output // bool: Publish alignments as CRAM (true) or BAM (false)
 
     main:
@@ -19,7 +19,7 @@ workflow CALL_PARALOGS {
         [[], []],
     )
 
-   ch_paraphase_vcf_tbis = PARAPHASE.out.vcf
+    ch_paraphase_vcf_tbis = PARAPHASE.out.vcf
         .transpose()
         .map { meta, vcf ->
             [['id': vcf.simpleName, 'family_id': meta.family_id], vcf, []]
@@ -44,8 +44,7 @@ workflow CALL_PARALOGS {
         false,
     )
 
-    ch_bcftools_reheader_in = ch_paraphase_vcf_tbis
-        .join(GAWK.out.output, failOnMismatch: true, failOnDuplicate: true)
+    ch_bcftools_reheader_in = ch_paraphase_vcf_tbis.join(GAWK.out.output, failOnMismatch: true, failOnDuplicate: true)
 
     BCFTOOLS_REHEADER(ch_bcftools_reheader_in, [[], []])
 
@@ -68,13 +67,13 @@ workflow CALL_PARALOGS {
     }
 
     emit:
-    bam        = PARAPHASE.out.bam                                         // channel: [ val(meta), path(bam)  ]
-    bai        = PARAPHASE.out.bai                                         // channel: [ val(meta), path(bai)  ]
+    bam        = PARAPHASE.out.bam // channel: [ val(meta), path(bam)  ]
+    bai        = PARAPHASE.out.bai // channel: [ val(meta), path(bai)  ]
     cram       = cram_output ? SAMTOOLS_CONVERT.out.cram : channel.empty() // channel: [ val(meta), path(cram) ]
     crai       = cram_output ? SAMTOOLS_CONVERT.out.crai : channel.empty() // channel: [ val(meta), path(crai) ]
-    json       = PARAPHASE.out.json                                        // channel: [ val(meta), path(json) ]
-    sample_vcf = PARAPHASE.out.vcf.transpose()                             // channel: [ val(meta), path(vcf)  ]
-    sample_tbi = PARAPHASE.out.vcf_index.transpose()                       // channel: [ val(meta), path(tbi)  ]
-    family_vcf = BCFTOOLS_MERGE.out.vcf                                    // channel: [ val(meta), path(vcf)  ]
-    family_tbi = BCFTOOLS_MERGE.out.index                                  // channel: [ val(meta), path(tbi)  ]
+    json       = PARAPHASE.out.json // channel: [ val(meta), path(json) ]
+    sample_vcf = PARAPHASE.out.vcf.transpose() // channel: [ val(meta), path(vcf)  ]
+    sample_tbi = PARAPHASE.out.vcf_index.transpose() // channel: [ val(meta), path(tbi)  ]
+    family_vcf = BCFTOOLS_MERGE.out.vcf // channel: [ val(meta), path(vcf)  ]
+    family_tbi = BCFTOOLS_MERGE.out.index // channel: [ val(meta), path(tbi)  ]
 }

--- a/subworkflows/local/call_repeat_expansions_strdust/main.nf
+++ b/subworkflows/local/call_repeat_expansions_strdust/main.nf
@@ -5,11 +5,11 @@ include { VCFEXPRESS     } from '../../../modules/nf-core/vcfexpress/main'
 
 workflow CALL_REPEAT_EXPANSIONS_STRDUST {
     take:
-    ch_bam_bai              // channel: [mandatory] [ val(meta), path(bam), path(bai) ]
-    ch_fasta                // channel: [mandatory] [ val(meta), path(fasta) ]
-    ch_fai                  // channel: [mandatory] [ val(meta), path(fai) ]
-    ch_bed                  // channel: [mandatory] [ val(meta), path(bed) ]
-    ch_vcfexpress_prelude   // path: [mandatory] lua file
+    ch_bam_bai // channel: [mandatory] [ val(meta), path(bam), path(bai) ]
+    ch_fasta // channel: [mandatory] [ val(meta), path(fasta) ]
+    ch_fai // channel: [mandatory] [ val(meta), path(fai) ]
+    ch_bed // channel: [mandatory] [ val(meta), path(bed) ]
+    ch_vcfexpress_prelude // path: [mandatory] lua file
 
     main:
 
@@ -33,7 +33,7 @@ workflow CALL_REPEAT_EXPANSIONS_STRDUST {
         .join(TABIX_TABIX.out.index, failOnDuplicate: true, failOnMismatch: true)
         .map { meta, vcf, tbi -> [[id: meta.family_id], vcf, tbi] }
         .groupTuple()
-        .map { meta, vcfs, tbis -> [ meta, vcfs, tbis, [] ] }
+        .map { meta, vcfs, tbis -> [meta, vcfs, tbis, []] }
 
     BCFTOOLS_MERGE(
         ch_bcftools_merge_in,
@@ -41,9 +41,8 @@ workflow CALL_REPEAT_EXPANSIONS_STRDUST {
     )
 
     emit:
-    sample_vcf  = VCFEXPRESS.out.vcf       // channel: [ val(meta), path(vcf) ]
-    sample_tbi  = TABIX_TABIX.out.index    // channel: [ val(meta), path(tbi) ]
-    family_vcf  = BCFTOOLS_MERGE.out.vcf   // channel: [ val(meta), path(vcf) ]
-    family_tbi  = BCFTOOLS_MERGE.out.index // channel: [ val(meta), path(tbi) ]
-
+    sample_vcf = VCFEXPRESS.out.vcf // channel: [ val(meta), path(vcf) ]
+    sample_tbi = TABIX_TABIX.out.index // channel: [ val(meta), path(tbi) ]
+    family_vcf = BCFTOOLS_MERGE.out.vcf // channel: [ val(meta), path(vcf) ]
+    family_tbi = BCFTOOLS_MERGE.out.index // channel: [ val(meta), path(tbi) ]
 }

--- a/subworkflows/local/call_repeat_expansions_trgt/main.nf
+++ b/subworkflows/local/call_repeat_expansions_trgt/main.nf
@@ -8,16 +8,15 @@ include { VCFEXPRESS       } from '../../../modules/nf-core/vcfexpress/main'
 
 workflow CALL_REPEAT_EXPANSIONS_TRGT {
     take:
-    ch_bam_bai              // channel: [mandatory] [ val(meta), path(bam), path(bai) ]
-    ch_fasta                // channel: [mandatory] [ val(meta), path(fasta) ]
-    ch_fai                  // channel: [mandatory] [ val(meta), path(fai) ]
-    ch_bed                  // channel: [mandatory] [ val(meta), path(bed) ]
-    cram_output             // bool: Publish alignments as CRAM (true) or BAM (false)
-    ch_vcfexpress_prelude   // path: [mandatory] lua file
+    ch_bam_bai // channel: [mandatory] [ val(meta), path(bam), path(bai) ]
+    ch_fasta // channel: [mandatory] [ val(meta), path(fasta) ]
+    ch_fai // channel: [mandatory] [ val(meta), path(fai) ]
+    ch_bed // channel: [mandatory] [ val(meta), path(bed) ]
+    cram_output // bool: Publish alignments as CRAM (true) or BAM (false)
+    ch_vcfexpress_prelude // path: [mandatory] lua file
 
     main:
-    ch_trgt_input = ch_bam_bai
-        .map { meta, bam, bai -> [meta, bam, bai, meta.sex == 1 ? 'XY' : 'XX'] }
+    ch_trgt_input = ch_bam_bai.map { meta, bam, bai -> [meta, bam, bai, meta.sex == 1 ? 'XY' : 'XX'] }
 
     // Run TRGT
     TRGT_GENOTYPE(
@@ -78,12 +77,12 @@ workflow CALL_REPEAT_EXPANSIONS_TRGT {
     )
 
     emit:
-    sample_vcf = BCFTOOLS_SORT.out.vcf                                      // channel: [ val(meta), path(vcf) ]
-    sample_tbi = BCFTOOLS_SORT.out.tbi                                      // channel: [ val(meta), path(tbi) ]
-    family_vcf = TRGT_MERGE.out.vcf                                         // channel: [ val(meta), path(vcf) ]
-    family_tbi = TRGT_MERGE.out.index                                       // channel: [ val(meta), path(tbi) ]
-    sample_bam = SAMTOOLS_SORT.out.bam                                      // channel: [ val(meta), path(bam) ]
-    sample_bai = SAMTOOLS_INDEX.out.index                                   // channel: [ val(meta), path(bai) ]
+    sample_vcf  = BCFTOOLS_SORT.out.vcf // channel: [ val(meta), path(vcf) ]
+    sample_tbi  = BCFTOOLS_SORT.out.tbi // channel: [ val(meta), path(tbi) ]
+    family_vcf  = TRGT_MERGE.out.vcf // channel: [ val(meta), path(vcf) ]
+    family_tbi  = TRGT_MERGE.out.index // channel: [ val(meta), path(tbi) ]
+    sample_bam  = SAMTOOLS_SORT.out.bam // channel: [ val(meta), path(bam) ]
+    sample_bai  = SAMTOOLS_INDEX.out.index // channel: [ val(meta), path(bai) ]
     sample_cram = cram_output ? SAMTOOLS_CONVERT.out.cram : channel.empty() // channel: [ val(meta), path(cram) ]
     sample_crai = cram_output ? SAMTOOLS_CONVERT.out.crai : channel.empty() // channel: [ val(meta), path(crai) ]
 }

--- a/subworkflows/local/call_snvs/main.nf
+++ b/subworkflows/local/call_snvs/main.nf
@@ -9,17 +9,16 @@ include { DNASCOPE_LONGREAD_CALL_SNVS as DNASCOPE_LONGREAD } from '../../../modu
 
 workflow CALL_SNVS {
     take:
-    ch_bam_bai_bed                  // channel: [mandatory] [ val(meta), path(bam), path(bai), path(call_regions_bed) ]
-    ch_fasta                        // channel: [mandatory] [ val(meta), path(fasta) ]
-    ch_fai                          // channel: [mandatory] [ val(meta), path(fai) ]
-    ch_par_bed                      // channel: [mandatory] [ val(meta), path(par_bed) ]
-    ch_sentieon_model_bundle        // channel: [mandatory] [ val(meta), path(model_bundle) ]
-    ch_sentieon_female_diploid_bed  // channel: [mandatory] [ val(meta), path(female_diploid_bed) ]
-    ch_sentieon_male_diploid_bed    // channel: [mandatory] [ val(meta), path(male_diploid_bed) ]
-    ch_sentieon_male_haploid_bed    // channel: [mandatory] [ val(meta), path(male_haploid_bed) ]
-    variant_caller                  // string: which variant caller to use, e.g. "deepvariant"
-    sentieon_tech                   // string: which sequencing tech produced the reads (sentieon)
-
+    ch_bam_bai_bed // channel: [mandatory] [ val(meta), path(bam), path(bai), path(call_regions_bed) ]
+    ch_fasta // channel: [mandatory] [ val(meta), path(fasta) ]
+    ch_fai // channel: [mandatory] [ val(meta), path(fai) ]
+    ch_par_bed // channel: [mandatory] [ val(meta), path(par_bed) ]
+    ch_sentieon_model_bundle // channel: [mandatory] [ val(meta), path(model_bundle) ]
+    ch_sentieon_female_diploid_bed // channel: [mandatory] [ val(meta), path(female_diploid_bed) ]
+    ch_sentieon_male_diploid_bed // channel: [mandatory] [ val(meta), path(male_diploid_bed) ]
+    ch_sentieon_male_haploid_bed // channel: [mandatory] [ val(meta), path(male_haploid_bed) ]
+    variant_caller // string: which variant caller to use, e.g. "deepvariant"
+    sentieon_tech // string: which sequencing tech produced the reads (sentieon)
 
     main:
     if (variant_caller.equals("deepvariant")) {
@@ -32,17 +31,16 @@ workflow CALL_SNVS {
             ch_par_bed,
         )
 
-        ch_vcf        = DEEPVARIANT_RUNDEEPVARIANT.out.vcf
-        ch_index      = DEEPVARIANT_RUNDEEPVARIANT.out.vcf_tbi
-        ch_gvcf       = DEEPVARIANT_RUNDEEPVARIANT.out.gvcf
+        ch_vcf = DEEPVARIANT_RUNDEEPVARIANT.out.vcf
+        ch_index = DEEPVARIANT_RUNDEEPVARIANT.out.vcf_tbi
+        ch_gvcf = DEEPVARIANT_RUNDEEPVARIANT.out.gvcf
         ch_gvcf_index = DEEPVARIANT_RUNDEEPVARIANT.out.gvcf_tbi
     }
     else if (variant_caller.equals("sentieon")) {
 
-        ch_bam_bai = ch_bam_bai_bed
-            .map { meta, bam, bai, _bed ->
-                [ meta, bam, bai ]
-            }
+        ch_bam_bai = ch_bam_bai_bed.map { meta, bam, bai, _bed ->
+            [meta, bam, bai]
+        }
 
         ch_bed = ch_bam_bai_bed
             .map { meta, _bam, _bai, bed ->
@@ -53,9 +51,9 @@ workflow CALL_SNVS {
                 female: meta.sex == 2
             }
 
-        ch_male_diploid_intersect_in   = makeIntersectChannel(ch_sentieon_male_diploid_bed, ch_bed.male, "diploid")
+        ch_male_diploid_intersect_in = makeIntersectChannel(ch_sentieon_male_diploid_bed, ch_bed.male, "diploid")
         ch_female_diploid_intersect_in = makeIntersectChannel(ch_sentieon_female_diploid_bed, ch_bed.female, "diploid")
-        ch_male_haploid_intersect_in   = makeIntersectChannel(ch_sentieon_male_haploid_bed, ch_bed.male, "haploid")
+        ch_male_haploid_intersect_in = makeIntersectChannel(ch_sentieon_male_haploid_bed, ch_bed.male, "haploid")
 
         ch_bedtools_intersect_in = ch_male_diploid_intersect_in
             .mix(ch_female_diploid_intersect_in)
@@ -66,22 +64,20 @@ workflow CALL_SNVS {
             [[], []],
         )
 
-        ch_intersected_calling_intervals = BEDTOOLS_INTERSECT.out.intersect
-            .branch {
-                meta, intersected_bed ->
-                diploid: meta.ploidy == "diploid"
-                    [ meta - meta.subMap('ploidy'), intersected_bed  ]
-                haploid: meta.ploidy == "haploid"
-                    [ meta - meta.subMap('ploidy'), intersected_bed  ]
-            }
+        ch_intersected_calling_intervals = BEDTOOLS_INTERSECT.out.intersect.branch { meta, intersected_bed ->
+            diploid: meta.ploidy == "diploid"
+            [meta - meta.subMap('ploidy'), intersected_bed]
+            haploid: meta.ploidy == "haploid"
+            [meta - meta.subMap('ploidy'), intersected_bed]
+        }
 
         ch_haploid_regions_out = ch_intersected_calling_intervals.haploid
-            .map {
-                meta, bed ->
-                if(bed && bed.size() > 0) {
-                    [ meta, bed ]
-                } else {
-                    [ meta, [] ]
+            .map { meta, bed ->
+                if (bed && bed.size() > 0) {
+                    [meta, bed]
+                }
+                else {
+                    [meta, []]
                 }
             }
             .mix(
@@ -114,16 +110,16 @@ workflow CALL_SNVS {
             [],
         )
 
-        ch_vcf        = BCFTOOLS_PLUGINFIXPLOIDY.out.vcf
-        ch_index      = BCFTOOLS_PLUGINFIXPLOIDY.out.tbi
-        ch_gvcf       = DNASCOPE_LONGREAD.out.gvcf
+        ch_vcf = BCFTOOLS_PLUGINFIXPLOIDY.out.vcf
+        ch_index = BCFTOOLS_PLUGINFIXPLOIDY.out.tbi
+        ch_gvcf = DNASCOPE_LONGREAD.out.gvcf
         ch_gvcf_index = DNASCOPE_LONGREAD.out.gvcf_tbi
     }
 
     emit:
-    vcf        = ch_vcf        // channel: [ val(meta), path(vcf) ]
-    index      = ch_index      // channel: [ val(meta), path(tbi) ]
-    gvcf       = ch_gvcf       // channel: [ val(meta), path(gvcf) ]
+    vcf        = ch_vcf // channel: [ val(meta), path(vcf) ]
+    index      = ch_index // channel: [ val(meta), path(tbi) ]
+    gvcf       = ch_gvcf // channel: [ val(meta), path(gvcf) ]
     gvcf_index = ch_gvcf_index // channel: [ val(meta), path(tbi) ]
 }
 

--- a/subworkflows/local/call_svs/main.nf
+++ b/subworkflows/local/call_svs/main.nf
@@ -93,12 +93,10 @@ workflow CALL_SVS {
         // Join SNV VCFs into input channels only if we want MAF track
         // Otherwise, we can skip the join and just pass an empty list to the module, since the MAF track is the only thing that needs the SNV VCFs.
         if (create_hificnv_maf_track) {
-            ch_for_hificnv = ch_bam_bai
-                .join(ch_snvs, failOnMismatch: true, failOnDuplicate: true)
+            ch_for_hificnv = ch_bam_bai.join(ch_snvs, failOnMismatch: true, failOnDuplicate: true)
         }
         else {
-            ch_for_hificnv = ch_bam_bai
-                .map { meta, bam, bai -> [meta, bam, bai, []] }
+            ch_for_hificnv = ch_bam_bai.map { meta, bam, bai -> [meta, bam, bai, []] }
         }
 
         // Select expected copynumber BED based on sex before passing it to the module
@@ -139,12 +137,10 @@ workflow CALL_SVS {
         // Join SNV VCFs into input channels only if we want MAF track
         // Otherwise, we can skip the join and just pass an empty list to the module, since the MAF track is the only thing that needs the SNV VCFs.
         if (create_sawfish_maf_track) {
-            ch_bam_vcf_for_sawfish_discover = ch_bam_bai
-                .join(ch_snvs, failOnMismatch: true, failOnDuplicate: true)
+            ch_bam_vcf_for_sawfish_discover = ch_bam_bai.join(ch_snvs, failOnMismatch: true, failOnDuplicate: true)
         }
         else {
-            ch_bam_vcf_for_sawfish_discover = ch_bam_bai
-                .map { meta, bam, bai -> [meta, bam, bai, []] }
+            ch_bam_vcf_for_sawfish_discover = ch_bam_bai.map { meta, bam, bai -> [meta, bam, bai, []] }
         }
 
         ch_sawfish_discover_input = ch_bam_vcf_for_sawfish_discover
@@ -217,11 +213,10 @@ workflow CALL_SVS {
         ch_sv_calls_filtered = ch_sv_calls
     }
 
-    ch_vcfexpress_input = ch_sv_calls_filtered
-        .multiMap { meta, vcf, _tbi ->
-            vcf: [meta, vcf]
-            sv_caller: meta.sv_caller
-        }
+    ch_vcfexpress_input = ch_sv_calls_filtered.multiMap { meta, vcf, _tbi ->
+        vcf: [meta, vcf]
+        sv_caller: meta.sv_caller
+    }
 
     VCFEXPRESS(
         ch_vcfexpress_input.vcf,
@@ -233,12 +228,11 @@ workflow CALL_SVS {
     // HiFiCNV doesn't have this issue, so we filter it out here, and add it back later.
 
     // Starting with getting the sample name from the VCF
-    ch_found_in_tagged_vcf = VCFEXPRESS.out.vcf
-        .branch { meta, _vcf ->
-            def callers_needing_reheader = ['severus', 'sniffles']
-            to_reheader: callers_needing_reheader.contains(meta.sv_caller)
-            no_reheader: !callers_needing_reheader.contains(meta.sv_caller)
-        }
+    ch_found_in_tagged_vcf = VCFEXPRESS.out.vcf.branch { meta, _vcf ->
+        def callers_needing_reheader = ['severus', 'sniffles']
+        to_reheader: callers_needing_reheader.contains(meta.sv_caller)
+        no_reheader: !callers_needing_reheader.contains(meta.sv_caller)
+    }
 
     BCFTOOLS_QUERY(
         ch_found_in_tagged_vcf.to_reheader.map { meta, vcf -> [meta, vcf, []] },
@@ -303,17 +297,17 @@ workflow CALL_SVS {
     )
 
     emit:
-    family_caller_vcf                  = SVDB_MERGE_BY_CALLER.out.vcf                                                                                                           // channel: [ val(meta), path(vcf) ]
-    family_caller_tbi                  = SVDB_MERGE_BY_CALLER.out.tbi                                                                                                           // channel: [ val(meta), path(tbi) ]
-    family_vcf                         = SVDB_MERGE_BY_FAMILY.out.vcf                                                                                                           // channel: [ val(meta), path(vcf) ]
-    family_tbi                         = SVDB_MERGE_BY_FAMILY.out.tbi                                                                                                           // channel: [ val(meta), path(tbi) ]
-    hificnv_depth                      = sv_callers_to_run.contains('hificnv') ? HIFICNV.out.depth : channel.empty()                                                            // channel: [ val(meta), path(bw) ]
-    hificnv_copynum                    = sv_callers_to_run.contains('hificnv') ? HIFICNV.out.copynum : channel.empty()                                                          // channel: [ val(meta), path(bedgraph) ]
-    hificnv_maf                        = sv_callers_to_run.contains('hificnv') ? HIFICNV.out.maf : channel.empty()                                                              // channel: [ val(meta), path(bw) ]
-    sawfish_depth_bw                   = sv_callers_to_run.contains('sawfish') ? addSampleIdFromSawfishPath(SAWFISH_JOINTCALL.out.depth_bw) : channel.empty()                   // channel: [ val(meta), path(bw) ]
-    sawfish_copynum_bedgraph           = sv_callers_to_run.contains('sawfish') ? addSampleIdFromSawfishPath(SAWFISH_JOINTCALL.out.copynum_bedgraph) : channel.empty()           // channel: [ val(meta), path(bedgraph) ]
+    family_caller_vcf                  = SVDB_MERGE_BY_CALLER.out.vcf // channel: [ val(meta), path(vcf) ]
+    family_caller_tbi                  = SVDB_MERGE_BY_CALLER.out.tbi // channel: [ val(meta), path(tbi) ]
+    family_vcf                         = SVDB_MERGE_BY_FAMILY.out.vcf // channel: [ val(meta), path(vcf) ]
+    family_tbi                         = SVDB_MERGE_BY_FAMILY.out.tbi // channel: [ val(meta), path(tbi) ]
+    hificnv_depth                      = sv_callers_to_run.contains('hificnv') ? HIFICNV.out.depth : channel.empty() // channel: [ val(meta), path(bw) ]
+    hificnv_copynum                    = sv_callers_to_run.contains('hificnv') ? HIFICNV.out.copynum : channel.empty() // channel: [ val(meta), path(bedgraph) ]
+    hificnv_maf                        = sv_callers_to_run.contains('hificnv') ? HIFICNV.out.maf : channel.empty() // channel: [ val(meta), path(bw) ]
+    sawfish_depth_bw                   = sv_callers_to_run.contains('sawfish') ? addSampleIdFromSawfishPath(SAWFISH_JOINTCALL.out.depth_bw) : channel.empty() // channel: [ val(meta), path(bw) ]
+    sawfish_copynum_bedgraph           = sv_callers_to_run.contains('sawfish') ? addSampleIdFromSawfishPath(SAWFISH_JOINTCALL.out.copynum_bedgraph) : channel.empty() // channel: [ val(meta), path(bedgraph) ]
     sawfish_gc_bias_corrected_depth_bw = sv_callers_to_run.contains('sawfish') ? addSampleIdFromSawfishPath(SAWFISH_JOINTCALL.out.gc_bias_corrected_depth_bw) : channel.empty() // channel: [ val(meta), path(bw) ]
-    sawfish_maf_bw                     = sv_callers_to_run.contains('sawfish') ? addSampleIdFromSawfishPath(SAWFISH_JOINTCALL.out.maf_bw) : channel.empty()                     // channel: [ val(meta), path(bw) ]
+    sawfish_maf_bw                     = sv_callers_to_run.contains('sawfish') ? addSampleIdFromSawfishPath(SAWFISH_JOINTCALL.out.maf_bw) : channel.empty() // channel: [ val(meta), path(bw) ]
 }
 
 def addCallerToMeta(ch_caller_calls, sv_caller) {

--- a/subworkflows/local/chromograph/main.nf
+++ b/subworkflows/local/chromograph/main.nf
@@ -10,14 +10,14 @@ include { TIDDIT_COV                                } from '../../../modules/nf-
 
 workflow CHROMOGRAPH {
     take:
-    ch_bam_bai        // channel: [ val(meta), path(bam), path(bai) ]
-    ch_vcf            // channel: [ val(meta), path(vcf) ]
-    ch_tbi            // channel: [ val(meta), path(tbi) ]
-    plot_coverage     // boolean
+    ch_bam_bai // channel: [ val(meta), path(bam), path(bai) ]
+    ch_vcf // channel: [ val(meta), path(vcf) ]
+    ch_tbi // channel: [ val(meta), path(tbi) ]
+    plot_coverage // boolean
     plot_autozygosity // boolean
 
     main:
-    ch_autozyg  = channel.empty()
+    ch_autozyg = channel.empty()
     ch_coverage = channel.empty()
 
     if (plot_coverage) {
@@ -26,17 +26,15 @@ workflow CHROMOGRAPH {
             [[], []],
         )
 
-        ch_coverage = TIDDIT_COV.out.wig
-            .map { meta, wig ->
-                // To match the VCF meta, which only has ID due to being split by bcftools +split
-                def new_meta = [id: meta.id]
-                [new_meta, wig]
-            }
+        ch_coverage = TIDDIT_COV.out.wig.map { meta, wig ->
+            // To match the VCF meta, which only has ID due to being split by bcftools +split
+            def new_meta = [id: meta.id]
+            [new_meta, wig]
+        }
     }
 
     if (plot_autozygosity) {
-        ch_vcf_tbi = ch_vcf
-            .join(ch_tbi, failOnMismatch: true, failOnDuplicate: true)
+        ch_vcf_tbi = ch_vcf.join(ch_tbi, failOnMismatch: true, failOnDuplicate: true)
 
         BCFTOOLS_ROH(
             ch_vcf_tbi,
@@ -70,8 +68,9 @@ workflow CHROMOGRAPH {
     }
 
     // Combine and filter only if there's data
-    ch_chromograph_input = ch_autozyg.ifEmpty([[],[]])
-        .combine(ch_coverage.ifEmpty([[],[]]))
+    ch_chromograph_input = ch_autozyg
+        .ifEmpty([[], []])
+        .combine(ch_coverage.ifEmpty([[], []]))
         .filter { autozyg_meta, _autozyg, coverage_meta, _coverage ->
             if (!autozyg_meta || !coverage_meta) {
                 return true

--- a/subworkflows/local/convert_input_files/main.nf
+++ b/subworkflows/local/convert_input_files/main.nf
@@ -6,31 +6,30 @@ include { SAMTOOLS_FASTQ  } from '../../../modules/nf-core/samtools/fastq/main'
 // into the respective output channels.
 workflow CONVERT_INPUT_FILES {
     take:
-    ch_input      // channel: [ val(meta), reads ]
-    convert_bam   //    bool: Should BAM files be converted to FASTQ
+    ch_input // channel: [ val(meta), reads ]
+    convert_bam //    bool: Should BAM files be converted to FASTQ
     convert_fastq //    bool: Should FASTQ files be converted to BAM
 
     main:
-    ch_reads_to_convert = ch_input
-        .branch { _meta, reads ->
-            fastq: reads.extension == 'gz'
-            bam: reads.extension == 'bam'
-        }
+    ch_reads_to_convert = ch_input.branch { _meta, reads ->
+        fastq: reads.extension == 'gz'
+        bam: reads.extension == 'bam'
+    }
 
-    ch_bam   = ch_reads_to_convert.bam
+    ch_bam = ch_reads_to_convert.bam
     ch_fastq = ch_reads_to_convert.fastq
 
-    if(convert_bam) {
-        SAMTOOLS_FASTQ (
+    if (convert_bam) {
+        SAMTOOLS_FASTQ(
             ch_reads_to_convert.bam,
-            false
+            false,
         )
 
         // Mix converted files back in
         ch_fastq = ch_fastq.mix(SAMTOOLS_FASTQ.out.other)
     }
-    if(convert_fastq) {
-        SAMTOOLS_IMPORT (
+    if (convert_fastq) {
+        SAMTOOLS_IMPORT(
             ch_reads_to_convert.fastq
         )
 
@@ -39,6 +38,6 @@ workflow CONVERT_INPUT_FILES {
     }
 
     emit:
-    bam   = ch_bam   // channel: [ val(meta), bam ]
+    bam   = ch_bam // channel: [ val(meta), bam ]
     fastq = ch_fastq // channel: [ val(meta), fastq ]
 }

--- a/subworkflows/local/genome_assembly/main.nf
+++ b/subworkflows/local/genome_assembly/main.nf
@@ -14,21 +14,19 @@ workflow GENOME_ASSEMBLY {
     main:
     if (trio_binning) {
         // First, we need to branch the samples based on their relationship
-        ch_branched_samples = ch_reads
-            .branch { meta, _reads ->
-                def is_parent = meta.relationship in ['father', 'mother']
-                paired_parents: is_parent && meta.has_other_parent
-                children_with_both_parents: meta.relationship == 'child' && meta.two_parents
-                other: true
-            }
+        ch_branched_samples = ch_reads.branch { meta, _reads ->
+            def is_parent = meta.relationship in ['father', 'mother']
+            paired_parents: is_parent && meta.has_other_parent
+            children_with_both_parents: meta.relationship == 'child' && meta.two_parents
+            other: true
+        }
 
         // Then, the files from parents of children with both parents will need to be concatenated before yak
         // in case there are multiple files for the same parent.
-        ch_paired_parents_for_yak = ch_branched_samples.paired_parents
-            .branch { _meta, fastqs ->
-                cat: fastqs.size() > 1
-                no_cat: fastqs.size() == 1
-            }
+        ch_paired_parents_for_yak = ch_branched_samples.paired_parents.branch { _meta, fastqs ->
+            cat: fastqs.size() > 1
+            no_cat: fastqs.size() == 1
+        }
 
         CAT_FASTQ(
             ch_paired_parents_for_yak.cat
@@ -73,11 +71,10 @@ workflow GENOME_ASSEMBLY {
             }
     }
     else {
-        ch_hifiasm_in = ch_reads
-            .multiMap { meta, reads ->
-                reads: [meta, reads, []]
-                yak: [meta, [], []]
-            }
+        ch_hifiasm_in = ch_reads.multiMap { meta, reads ->
+            reads: [meta, reads, []]
+            yak: [meta, [], []]
+        }
     }
 
     HIFIASM_BINS(
@@ -104,11 +101,9 @@ workflow GENOME_ASSEMBLY {
         ch_hifiasm_assembly_in.bins,
     )
 
-    ch_gfastats_paternal_in = HIFIASM_ASSEMBLY.out.hap1_contigs
-        .map { meta, fasta -> [meta + ['haplotype': 1], fasta] }
+    ch_gfastats_paternal_in = HIFIASM_ASSEMBLY.out.hap1_contigs.map { meta, fasta -> [meta + ['haplotype': 1], fasta] }
 
-    ch_gfastats_maternal_in = HIFIASM_ASSEMBLY.out.hap2_contigs
-        .map { meta, fasta -> [meta + ['haplotype': 2], fasta] }
+    ch_gfastats_maternal_in = HIFIASM_ASSEMBLY.out.hap2_contigs.map { meta, fasta -> [meta + ['haplotype': 2], fasta] }
 
     GFASTATS(
         ch_gfastats_paternal_in.mix(ch_gfastats_maternal_in),
@@ -122,6 +117,6 @@ workflow GENOME_ASSEMBLY {
     )
 
     emit:
-    assembled_haplotypes = GFASTATS.out.assembly         // channel: [ val(meta), path(fasta) ]
+    assembled_haplotypes = GFASTATS.out.assembly // channel: [ val(meta), path(fasta) ]
     assembly_summary     = GFASTATS.out.assembly_summary // channel: [ val(meta), path(assembly_summary) ]
 }

--- a/subworkflows/local/gvcf_glnexus_norm_variants/main.nf
+++ b/subworkflows/local/gvcf_glnexus_norm_variants/main.nf
@@ -12,30 +12,28 @@ include { VCFEXPRESS                                 } from '../../../modules/nf
 
 workflow GVCF_GLNEXUS_NORM_VARIANTS {
     take:
-    ch_gvcfs              // channel: [mandatory] [ val(meta), path(gvcfs)     ]
-    ch_tbis               // channel: [mandatory] [ val(meta), path(tbis)      ]
-    ch_bed                // channel: [optional]  [ val(meta), path(input_bed) ]
-    ch_fasta              // channel: [mandatory] [ val(meta), path(fasta)     ]
-    ch_fai                // channel: [mandatory] [ val(meta), path(fai)       ]
+    ch_gvcfs // channel: [mandatory] [ val(meta), path(gvcfs)     ]
+    ch_tbis // channel: [mandatory] [ val(meta), path(tbis)      ]
+    ch_bed // channel: [optional]  [ val(meta), path(input_bed) ]
+    ch_fasta // channel: [mandatory] [ val(meta), path(fasta)     ]
+    ch_fai // channel: [mandatory] [ val(meta), path(fai)       ]
     ch_vcfexpress_prelude // path: [mandatory] lua file
 
     main:
     ch_merged_family_gvcf = channel.empty()
 
     // Branching gVCFs and TBI channels by caller, as they need to be processed differently in the next steps
-    branched_gvcfs = ch_gvcfs
-        .branch { meta, _gvcfs ->
-            mitorsaw: meta.caller == "mitorsaw"
-            sentieon: meta.caller == "sentieon"
-            deepvariant: meta.caller == "deepvariant"
-        }
+    branched_gvcfs = ch_gvcfs.branch { meta, _gvcfs ->
+        mitorsaw: meta.caller == "mitorsaw"
+        sentieon: meta.caller == "sentieon"
+        deepvariant: meta.caller == "deepvariant"
+    }
 
-    branched_tbis = ch_tbis
-        .branch { meta, _tbi ->
-            mitorsaw: meta.caller == "mitorsaw"
-            sentieon: meta.caller == "sentieon"
-            deepvariant: meta.caller == "deepvariant"
-        }
+    branched_tbis = ch_tbis.branch { meta, _tbi ->
+        mitorsaw: meta.caller == "mitorsaw"
+        sentieon: meta.caller == "sentieon"
+        deepvariant: meta.caller == "deepvariant"
+    }
 
     // GLNEXUS processes deepvariant gVCFs
     GLNEXUS(
@@ -74,7 +72,8 @@ workflow GVCF_GLNEXUS_NORM_VARIANTS {
     ch_merged_family_gvcf_sentieon = BCFTOOLS_PLUGINFIXPLOIDY.out.vcf
 
     // BCFTOOLS_MERGE is used for the mitochondrial specific caller
-    ch_bcftools_merge_in = branched_gvcfs.mitorsaw.join(branched_tbis.mitorsaw, failOnMismatch: true, failOnDuplicate: true)
+    ch_bcftools_merge_in = branched_gvcfs.mitorsaw
+        .join(branched_tbis.mitorsaw, failOnMismatch: true, failOnDuplicate: true)
         .map { meta, gvcfs, tbis ->
             [meta, gvcfs, tbis, []]
         }
@@ -110,6 +109,6 @@ workflow GVCF_GLNEXUS_NORM_VARIANTS {
     )
 
     emit:
-    vcf   = BCFTOOLS_NORM_MULTISAMPLE.out.vcf                                        // channel: [ val(meta), path(vcf) ]
+    vcf   = BCFTOOLS_NORM_MULTISAMPLE.out.vcf // channel: [ val(meta), path(vcf) ]
     index = BCFTOOLS_NORM_MULTISAMPLE.out.tbi.mix(BCFTOOLS_NORM_MULTISAMPLE.out.csi) // channel: [ val(meta), path(tbi/csi) ]
 }

--- a/subworkflows/local/hiphase/main.nf
+++ b/subworkflows/local/hiphase/main.nf
@@ -2,20 +2,19 @@ include { HIPHASE as RUN_HIPHASE } from '../../../modules/nf-core/hiphase/main'
 
 workflow HIPHASE {
     take:
-    ch_snv_vcf           // channel: [ val(meta), path(vcf) ]
-    ch_snv_vcf_index     // channel: [ val(meta), path(tbi) ]
-    ch_sv_vcf            // channel: [ val(meta), path(vcf) ] Optional
-    ch_sv_vcf_index      // channel: [ val(meta), path(tbi) ] Optional
-    ch_bam_bai           // channel: [ val(meta), path(bam), path(bai) ]
+    ch_snv_vcf // channel: [ val(meta), path(vcf) ]
+    ch_snv_vcf_index // channel: [ val(meta), path(tbi) ]
+    ch_sv_vcf // channel: [ val(meta), path(vcf) ] Optional
+    ch_sv_vcf_index // channel: [ val(meta), path(tbi) ] Optional
+    ch_bam_bai // channel: [ val(meta), path(bam), path(bai) ]
     ch_family_to_samples // channel: [ val(meta), val( [ sample_ids ] ) ]
-    fasta                // channel: [ val(meta), path(fasta) ]
-    fai                  // channel: [ val(meta), path(fai) ]
-    phase_with_svs       // bool: Whether to include SVs in phasing (true) or not (false)
+    fasta // channel: [ val(meta), path(fasta) ]
+    fai // channel: [ val(meta), path(fai) ]
+    phase_with_svs // bool: Whether to include SVs in phasing (true) or not (false)
 
     main:
     // Prepare SNV VCF with index
-    ch_snv_vcf_tbi = ch_snv_vcf
-        .join(ch_snv_vcf_index, failOnMismatch: true, failOnDuplicate: true)
+    ch_snv_vcf_tbi = ch_snv_vcf.join(ch_snv_vcf_index, failOnMismatch: true, failOnDuplicate: true)
 
     // Group BAM files by family and join with SNV VCF
     ch_hiphase_bam_snv = ch_bam_bai
@@ -25,20 +24,16 @@ workflow HIPHASE {
 
     // Prepare input based on whether SVs are included
     if (phase_with_svs) {
-        ch_sv_vcf_tbi = ch_sv_vcf
-            .join(ch_sv_vcf_index, failOnMismatch: true, failOnDuplicate: true)
+        ch_sv_vcf_tbi = ch_sv_vcf.join(ch_sv_vcf_index, failOnMismatch: true, failOnDuplicate: true)
 
-        ch_bam_vcf = ch_hiphase_bam_snv
-            .join(ch_sv_vcf_tbi, failOnMismatch: true, failOnDuplicate: true)
+        ch_bam_vcf = ch_hiphase_bam_snv.join(ch_sv_vcf_tbi, failOnMismatch: true, failOnDuplicate: true)
     }
     else {
-       ch_bam_vcf = ch_hiphase_bam_snv
-            .map { meta, bams, bais, snv_vcf, snv_tbi -> [meta, bams, bais, snv_vcf, snv_tbi, [], []] }
+        ch_bam_vcf = ch_hiphase_bam_snv.map { meta, bams, bais, snv_vcf, snv_tbi -> [meta, bams, bais, snv_vcf, snv_tbi, [], []] }
     }
 
     // Adding sample IDs to input tuples
-    ch_hiphase_in = ch_bam_vcf
-        .join(ch_family_to_samples, failOnMismatch: true, failOnDuplicate: true)
+    ch_hiphase_in = ch_bam_vcf.join(ch_family_to_samples, failOnMismatch: true, failOnDuplicate: true)
     // Run HiPhase
     RUN_HIPHASE(
         ch_hiphase_in,
@@ -67,9 +62,9 @@ workflow HIPHASE {
         }
 
     emit:
-    phased_snvs = RUN_HIPHASE.out.vcfs                                                  // channel: [ val(meta), path(vcf) ]
-    phased_snvs_tbi = RUN_HIPHASE.out.vcfs_indexes                                      // channel: [ val(meta), path(tbi) ]
-    phased_svs = phase_with_svs ? RUN_HIPHASE.out.sv_vcfs : ch_sv_vcf                   // channel: [ val(meta), path(vcf) ]
-    phased_svs_tbi = phase_with_svs ? RUN_HIPHASE.out.sv_vcfs_indexes : ch_sv_vcf_index // channel: [ val(meta), path(tbi) ]
-    haplotagged_bam_bai = ch_haplotagged_bam_bai                                        // channel: [ val(meta), path(bam), path(bai) ]
+    phased_snvs         = RUN_HIPHASE.out.vcfs // channel: [ val(meta), path(vcf) ]
+    phased_snvs_tbi     = RUN_HIPHASE.out.vcfs_indexes // channel: [ val(meta), path(tbi) ]
+    phased_svs          = phase_with_svs ? RUN_HIPHASE.out.sv_vcfs : ch_sv_vcf // channel: [ val(meta), path(vcf) ]
+    phased_svs_tbi      = phase_with_svs ? RUN_HIPHASE.out.sv_vcfs_indexes : ch_sv_vcf_index // channel: [ val(meta), path(tbi) ]
+    haplotagged_bam_bai = ch_haplotagged_bam_bai // channel: [ val(meta), path(bam), path(bai) ]
 }

--- a/subworkflows/local/longphase/main.nf
+++ b/subworkflows/local/longphase/main.nf
@@ -7,17 +7,16 @@ include { SPLIT_MULTISAMPLE_VCF } from '../../../subworkflows/local/split_multis
 
 workflow LONGPHASE {
     take:
-    ch_snv_vcf           // channel: [ val(meta), path(vcf) ]
-    ch_sv_vcf            // channel: [ val(meta), path(vcf) ] Optional
-    ch_bam_bai           // channel: [ val(meta), path(bam), path(bai) ]
+    ch_snv_vcf // channel: [ val(meta), path(vcf) ]
+    ch_sv_vcf // channel: [ val(meta), path(vcf) ] Optional
+    ch_bam_bai // channel: [ val(meta), path(bam), path(bai) ]
     ch_family_to_samples // channel: [ val(meta), val(list_of_sample_ids) ]
-    fasta                // channel: [ val(meta), path(fasta) ]
-    fai                  // channel: [ val(meta), path(fai) ]
-    phase_with_svs       // bool: Whether to include SVs in phasing (true) or not (false)
+    fasta // channel: [ val(meta), path(fasta) ]
+    fai // channel: [ val(meta), path(fai) ]
+    phase_with_svs // bool: Whether to include SVs in phasing (true) or not (false)
 
     main:
-    ch_snv_with_type = ch_snv_vcf
-        .map { meta, vcf -> [meta, vcf, "snv"] }
+    ch_snv_with_type = ch_snv_vcf.map { meta, vcf -> [meta, vcf, "snv"] }
 
     if (phase_with_svs) {
         ch_split_in = ch_sv_vcf
@@ -33,13 +32,12 @@ workflow LONGPHASE {
         ch_family_to_samples,
     )
 
-    ch_split_vcfs = SPLIT_MULTISAMPLE_VCF.out.split_vcf
-        .branch { meta, vcf, variant_type ->
-            sv: variant_type == 'sv'
-            [meta, vcf]
-            snv: variant_type == 'snv'
-            [meta, vcf]
-        }
+    ch_split_vcfs = SPLIT_MULTISAMPLE_VCF.out.split_vcf.branch { meta, vcf, variant_type ->
+        sv: variant_type == 'sv'
+        [meta, vcf]
+        snv: variant_type == 'snv'
+        [meta, vcf]
+    }
 
     ch_bam_vcf = ch_bam_bai
         .map { meta, bam, bai -> [[id: meta.id, family_id: meta.family_id], bam, bai] }
@@ -51,8 +49,7 @@ workflow LONGPHASE {
             .map { meta, bam, bai, snvs, svs -> [meta, bam, bai, snvs, svs, []] }
     }
     else {
-        ch_longphase_phase_in = ch_bam_vcf
-            .map { meta, bam, bai, snvs -> [meta, bam, bai, snvs, [], []] }
+        ch_longphase_phase_in = ch_bam_vcf.map { meta, bam, bai, snvs -> [meta, bam, bai, snvs, [], []] }
     }
 
     LONGPHASE_PHASE(
@@ -79,22 +76,20 @@ workflow LONGPHASE {
         fasta.join(fai, failOnMismatch: true, failOnDuplicate: true).collect(),
     )
 
-    ch_phased_family_vcfs = BCFTOOLS_MERGE.out.vcf
-        .branch { meta, vcf ->
-            snv: meta.variant_type == 'snv'
-            [meta - meta.subMap('variant_type'), vcf]
-            sv: meta.variant_type == 'sv'
-            [meta - meta.subMap('variant_type'), vcf]
-        }
+    ch_phased_family_vcfs = BCFTOOLS_MERGE.out.vcf.branch { meta, vcf ->
+        snv: meta.variant_type == 'snv'
+        [meta - meta.subMap('variant_type'), vcf]
+        sv: meta.variant_type == 'sv'
+        [meta - meta.subMap('variant_type'), vcf]
+    }
 
 
-    ch_phased_family_vcf_index = BCFTOOLS_MERGE.out.index
-        .branch { meta, tbi ->
-            snv: meta.variant_type == 'snv'
-            [meta - meta.subMap('variant_type'), tbi]
-            sv: meta.variant_type == 'sv'
-            [meta - meta.subMap('variant_type'), tbi]
-        }
+    ch_phased_family_vcf_index = BCFTOOLS_MERGE.out.index.branch { meta, tbi ->
+        snv: meta.variant_type == 'snv'
+        [meta - meta.subMap('variant_type'), tbi]
+        sv: meta.variant_type == 'sv'
+        [meta - meta.subMap('variant_type'), tbi]
+    }
 
     ch_phased_family_snvs = ch_phased_family_vcfs.snv
     ch_phased_family_snvs_tbi = ch_phased_family_vcf_index.snv
@@ -109,8 +104,7 @@ workflow LONGPHASE {
             .map { meta, snvs, svs -> [meta, snvs, svs, []] }
     }
     else {
-        ch_vcfs_for_haplotag = LONGPHASE_PHASE.out.snv_vcf
-            .map { meta, vcf -> [meta, vcf, [], []] }
+        ch_vcfs_for_haplotag = LONGPHASE_PHASE.out.snv_vcf.map { meta, vcf -> [meta, vcf, [], []] }
     }
 
     // Making sure to keep the full meta we get in case downstream processes need it
@@ -131,13 +125,12 @@ workflow LONGPHASE {
         LONGPHASE_HAPLOTAG.out.bam
     )
 
-    ch_bam_bai_haplotagged = LONGPHASE_HAPLOTAG.out.bam
-        .join(SAMTOOLS_INDEX.out.index, failOnMismatch: true, failOnDuplicate: true)
+    ch_bam_bai_haplotagged = LONGPHASE_HAPLOTAG.out.bam.join(SAMTOOLS_INDEX.out.index, failOnMismatch: true, failOnDuplicate: true)
 
     emit:
-    phased_family_snvs     = ch_phased_family_snvs     // channel: [ val(meta), path(vcf) ]
+    phased_family_snvs     = ch_phased_family_snvs // channel: [ val(meta), path(vcf) ]
     phased_family_snvs_tbi = ch_phased_family_snvs_tbi // channel: [ val(meta), path(tbi) ]
-    phased_family_svs      = ch_phased_family_svs      // channel: [ val(meta), path(vcf) ]
-    phased_family_svs_tbi  = ch_phased_family_svs_tbi  // channel: [ val(meta), path(tbi) ]
-    haplotagged_bam_bai    = ch_bam_bai_haplotagged    // channel: [ val(meta), path(bam), path(bai) ]
+    phased_family_svs      = ch_phased_family_svs // channel: [ val(meta), path(vcf) ]
+    phased_family_svs_tbi  = ch_phased_family_svs_tbi // channel: [ val(meta), path(tbi) ]
+    haplotagged_bam_bai    = ch_bam_bai_haplotagged // channel: [ val(meta), path(bam), path(bai) ]
 }

--- a/subworkflows/local/phasing/main.nf
+++ b/subworkflows/local/phasing/main.nf
@@ -21,7 +21,6 @@ workflow PHASING {
     ch_pedigree // channel: [ val(meta), path(pedigree) ]
 
     main:
-    // Phase variants and haplotag reads with Longphase
     if (phaser.equals("longphase")) {
 
         LONGPHASE(

--- a/subworkflows/local/phasing/main.nf
+++ b/subworkflows/local/phasing/main.nf
@@ -7,18 +7,18 @@ include { QC_PHASING       } from '../../../subworkflows/local/qc_phasing/main'
 
 workflow PHASING {
     take:
-    ch_snv_vcf           // channel: [ val(meta), path(vcf) ]
-    ch_snv_vcf_index     // channel: [ val(meta), path(tbi) ]
-    ch_sv_vcf            // channel: [ val(meta), path(vcf) ] Optional
-    ch_sv_vcf_index      // channel: [ val(meta), path(tbi) ] Optional
-    ch_bam_bai           // channel: [ val(meta), path(bam), path(bai) ]
+    ch_snv_vcf // channel: [ val(meta), path(vcf) ]
+    ch_snv_vcf_index // channel: [ val(meta), path(tbi) ]
+    ch_sv_vcf // channel: [ val(meta), path(vcf) ] Optional
+    ch_sv_vcf_index // channel: [ val(meta), path(tbi) ] Optional
+    ch_bam_bai // channel: [ val(meta), path(bam), path(bai) ]
     ch_family_to_samples // channel: [ val(meta), val(set_of_sample_ids) ]
-    fasta                // channel: [ val(meta), path(fasta) ]
-    fai                  // channel: [ val(meta), path(fai) ]
-    phaser               // string:  Phasing tool to use
-    phase_with_svs       // bool:    Whether to include SVs in phasing (true) or not (false)
-    cram_output          // bool:    Publish alignments as CRAM (true) or BAM (false)
-    ch_pedigree          // channel: [ val(meta), path(pedigree) ]
+    fasta // channel: [ val(meta), path(fasta) ]
+    fai // channel: [ val(meta), path(fai) ]
+    phaser // string:  Phasing tool to use
+    phase_with_svs // bool:    Whether to include SVs in phasing (true) or not (false)
+    cram_output // bool:    Publish alignments as CRAM (true) or BAM (false)
+    ch_pedigree // channel: [ val(meta), path(pedigree) ]
 
     main:
     // Phase variants and haplotag reads with Longphase
@@ -40,7 +40,6 @@ workflow PHASING {
         ch_phased_family_svs_tbi = phase_with_svs ? LONGPHASE.out.phased_family_svs_tbi : ch_sv_vcf_index
         ch_bam_bai_haplotagged = LONGPHASE.out.haplotagged_bam_bai
     }
-    // Phase variants and haplotag reads with WhatsHap
     else if (phaser.equals("whatshap")) {
 
         WHATSHAP(
@@ -58,7 +57,6 @@ workflow PHASING {
         ch_phased_family_svs_tbi = ch_sv_vcf_index
         ch_bam_bai_haplotagged = WHATSHAP.out.haplotagged_bam_bai
     }
-    // Phase variants and haplotag reads with HiPhase
     else if (phaser.equals("hiphase")) {
 
         HIPHASE(
@@ -100,15 +98,15 @@ workflow PHASING {
     }
 
     emit:
-    phased_family_snvs     = ch_phased_family_snvs                                    // channel: [ val(meta), path(vcf) ]
-    phased_family_snvs_tbi = ch_phased_family_snvs_tbi                                // channel: [ val(meta), path(tbi) ]
-    phased_family_svs      = ch_phased_family_svs                                     // channel: [ val(meta), path(vcf) ]
-    phased_family_svs_tbi  = ch_phased_family_svs_tbi                                 // channel: [ val(meta), path(tbi) ]
-    haplotagged_bam_bai    = ch_bam_bai_haplotagged                                   // channel: [ val(meta), path(bam), path(bai) ]
+    phased_family_snvs     = ch_phased_family_snvs // channel: [ val(meta), path(vcf) ]
+    phased_family_snvs_tbi = ch_phased_family_snvs_tbi // channel: [ val(meta), path(tbi) ]
+    phased_family_svs      = ch_phased_family_svs // channel: [ val(meta), path(vcf) ]
+    phased_family_svs_tbi  = ch_phased_family_svs_tbi // channel: [ val(meta), path(tbi) ]
+    haplotagged_bam_bai    = ch_bam_bai_haplotagged // channel: [ val(meta), path(bam), path(bai) ]
     haplotagged_cram_crai  = cram_output ? ch_haplotagged_cram_crai : channel.empty() // channel: [ val(meta), path(cram), path(crai) ]
-    stats                  = QC_PHASING.out.phasing_stats                             // channel: [ val(meta), path("*.stats.tsv") ]
-    blocks                 = QC_PHASING.out.phasing_blocks                            // channel: [ val(meta), path("*.blocks.gtf.gz") ]
-    blocks_index           = QC_PHASING.out.phasing_blocks_index                      // channel: [ val(meta), path("*.blocks.gtf.gz.tbi") ]
-    haplotagging_stats     = QC_PHASING.out.haplotagging_stats                        // channel: [ val(meta), path("*.txt") ]
-    haplotagging_arrow     = QC_PHASING.out.haplotagging_arrow                        // channel: [ val(meta), path("*.arrow") ]
+    stats                  = QC_PHASING.out.phasing_stats // channel: [ val(meta), path("*.stats.tsv") ]
+    blocks                 = QC_PHASING.out.phasing_blocks // channel: [ val(meta), path("*.blocks.gtf.gz") ]
+    blocks_index           = QC_PHASING.out.phasing_blocks_index // channel: [ val(meta), path("*.blocks.gtf.gz.tbi") ]
+    haplotagging_stats     = QC_PHASING.out.haplotagging_stats // channel: [ val(meta), path("*.txt") ]
+    haplotagging_arrow     = QC_PHASING.out.haplotagging_arrow // channel: [ val(meta), path("*.arrow") ]
 }

--- a/subworkflows/local/prepare_gens_inputs/main.nf
+++ b/subworkflows/local/prepare_gens_inputs/main.nf
@@ -8,12 +8,12 @@ include { SAMTOOLS_VIEW                } from '../../../modules/nf-core/samtools
 
 workflow PREPARE_GENS_INPUTS {
     take:
-    ch_bam                     // channel: [mandatory] [ val(meta), path(bam), path(bai) ]
-    ch_gvcf                    // channel: [mandatory] [ val(meta), path(gvcfs)], [path(tbis) ]
-    ch_baf_positions           // channel: [mandatory] [ val(meta), path(gz) ]
+    ch_bam // channel: [mandatory] [ val(meta), path(bam), path(bai) ]
+    ch_gvcf // channel: [mandatory] [ val(meta), path(gvcfs)], [path(tbis) ]
+    ch_baf_positions // channel: [mandatory] [ val(meta), path(gz) ]
     ch_panel_of_normals_female // channel: [mandatory] [ val(meta), path(hd5) ]
-    ch_panel_of_normals_male   // channel: [mandatory] [ val(meta), path(hd5) ]
-    ch_mosdepth_bins           // channel: [mandatory] [ val(meta), path(bed) ]
+    ch_panel_of_normals_male // channel: [mandatory] [ val(meta), path(hd5) ]
+    ch_mosdepth_bins // channel: [mandatory] [ val(meta), path(bed) ]
 
     main:
     ch_mosdepth_in = ch_bam
@@ -55,11 +55,10 @@ workflow PREPARE_GENS_INPUTS {
 
     CAT_CAT(ch_cat_input)
 
-    ch_branched = CAT_CAT.out.file_out
-        .branch { meta, _file ->
-            male: meta.sex == 1
-            female: meta.sex == 2
-        }
+    ch_branched = CAT_CAT.out.file_out.branch { meta, _file ->
+        male: meta.sex == 1
+        female: meta.sex == 2
+    }
 
     ch_readcounts_input = ch_branched.male
         .combine(ch_panel_of_normals_male)
@@ -76,12 +75,10 @@ workflow PREPARE_GENS_INPUTS {
         ch_readcounts_input.pon,
     )
 
-    ch_gens_input = GATK4_DENOISEREADCOUNTS.out.standardized
-        .join(ch_gvcf)
+    ch_gens_input = GATK4_DENOISEREADCOUNTS.out.standardized.join(ch_gvcf)
 
     // Generate final outputs
-    baf_positions = ch_baf_positions
-        .map { _meta, pos -> pos }
+    baf_positions = ch_baf_positions.map { _meta, pos -> pos }
 
     PREPARECOVANDBAF(
         ch_gens_input,

--- a/subworkflows/local/prepare_references/main.nf
+++ b/subworkflows/local/prepare_references/main.nf
@@ -5,10 +5,10 @@ include { UNTAR as UNTAR_VEP_CACHE } from '../../../modules/nf-core/untar/main'
 
 workflow PREPARE_REFERENCES {
     take:
-    fasta_in        // channel: [ val(meta), path(fasta) ]
-    fai_in          // channel: [ val(meta), path(fai) ]
-    ch_vep_cache    // channel: [ val(meta), path(cache) ]
-    gunzip_fasta    // boolean: should we gunzip fasta
+    fasta_in // channel: [ val(meta), path(fasta) ]
+    fai_in // channel: [ val(meta), path(fai) ]
+    ch_vep_cache // channel: [ val(meta), path(cache) ]
+    gunzip_fasta // boolean: should we gunzip fasta
     untar_vep_cache // boolean: should we untar vep cache
 
     main:
@@ -16,10 +16,9 @@ workflow PREPARE_REFERENCES {
 
     // Will not catch cases where fasta is bgzipped
     if (gunzip_fasta) {
-        ch_fasta = GUNZIP_FASTA ( fasta_in )
-            .gunzip
-            .collect()
-    } else {
+        ch_fasta = GUNZIP_FASTA(fasta_in).gunzip.collect()
+    }
+    else {
         ch_fasta = fasta_in
     }
 
@@ -29,9 +28,9 @@ workflow PREPARE_REFERENCES {
             false,
         )
 
-        ch_fai = SAMTOOLS_FAIDX.out.fai
-            .collect()
-    } else {
+        ch_fai = SAMTOOLS_FAIDX.out.fai.collect()
+    }
+    else {
         ch_fai = fai_in
     }
 
@@ -46,8 +45,8 @@ workflow PREPARE_REFERENCES {
     }
 
     emit:
-    mmi           = MINIMAP2_INDEX.out.index.collect()                                   // channel: [ val(meta), path(mmi) ]
-    fai           = ch_fai                                                               // channel: [ val(meta), path(fai) ]
-    fasta         = ch_fasta                                                             // channel: [ val(meta), path(fasta) ]
+    mmi           = MINIMAP2_INDEX.out.index.collect() // channel: [ val(meta), path(mmi) ]
+    fai           = ch_fai // channel: [ val(meta), path(fai) ]
+    fasta         = ch_fasta // channel: [ val(meta), path(fasta) ]
     vep_resources = untar_vep_cache ? UNTAR_VEP_CACHE.out.untar.collect() : ch_vep_cache // channel: [ val(meta), path(cache) ]
 }

--- a/subworkflows/local/qc_aligned_reads/main.nf
+++ b/subworkflows/local/qc_aligned_reads/main.nf
@@ -4,10 +4,10 @@ include { MOSDEPTH       } from '../../../modules/nf-core/mosdepth/main'
 include { SAMBAMBA_DEPTH } from '../../../modules/nf-core/sambamba/depth/main'
 workflow QC_ALIGNED_READS {
     take:
-    ch_bam_bai         // channel: [ val(meta), [bam, bai] ]
-    ch_fasta           // channel: [ val(meta), fasta ]
-    ch_mosdepth_bed    // channel: [ val(meta), bed ]
-    ch_sambamba_bed    // channel: [ val(meta), bed ]
+    ch_bam_bai // channel: [ val(meta), [bam, bai] ]
+    ch_fasta // channel: [ val(meta), fasta ]
+    ch_mosdepth_bed // channel: [ val(meta), bed ]
+    ch_sambamba_bed // channel: [ val(meta), bed ]
     run_sambamba_depth // bool: Should sambamba depth be run?
 
     main:
@@ -21,8 +21,8 @@ workflow QC_ALIGNED_READS {
         ch_bam_bai
     )
 
-    ch_mosdepth_in = ch_bam_bai
-        .combine(ch_mosdepth_bed.map { _meta, bed -> bed }.toList()) // toList() enables passing [] if ch_bed is empty
+    ch_mosdepth_in = ch_bam_bai.combine(ch_mosdepth_bed.map { _meta, bed -> bed }.toList())
+    // toList() enables passing [] if ch_bed is empty
 
     MOSDEPTH(
         ch_mosdepth_in,
@@ -40,15 +40,15 @@ workflow QC_ALIGNED_READS {
     }
 
     emit:
-    cramino_stats         = CRAMINO.out.stats        // channel: [ val(meta), path(txt)        ]
-    cramino_arrow         = CRAMINO.out.arrow        // channel: [ val(meta), path(arrow)      ]
-    fastqc_html           = FASTQC.out.html          // channel: [ val(meta), path(html)       ]
-    fastqc_zip            = FASTQC.out.zip           // channel: [ val(meta), path(zip)        ]
+    cramino_stats         = CRAMINO.out.stats // channel: [ val(meta), path(txt)        ]
+    cramino_arrow         = CRAMINO.out.arrow // channel: [ val(meta), path(arrow)      ]
+    fastqc_html           = FASTQC.out.html // channel: [ val(meta), path(html)       ]
+    fastqc_zip            = FASTQC.out.zip // channel: [ val(meta), path(zip)        ]
     mosdepth_summary      = MOSDEPTH.out.summary_txt // channel: [ val(meta), path(txt)        ]
-    mosdepth_global_dist  = MOSDEPTH.out.global_txt  // channel: [ val(meta), path(txt)        ]
+    mosdepth_global_dist  = MOSDEPTH.out.global_txt // channel: [ val(meta), path(txt)        ]
     mosdepth_regions_dist = MOSDEPTH.out.regions_txt // channel: [ val(meta), path(txt)        ]
     mosdepth_per_base_d4  = MOSDEPTH.out.per_base_d4 // channel: [ val(meta), path(d4)         ]
     mosdepth_regions_bed  = MOSDEPTH.out.regions_bed // channel: [ val(meta), path(bed.gz)     ]
     mosdepth_regions_csi  = MOSDEPTH.out.regions_csi // channel: [ val(meta), path(bed.gz.csi) ]
-    sambamba_depth_bed    = ch_sambamba_depth_bed    // channel: [ val(meta), path(bed)        ]
+    sambamba_depth_bed    = ch_sambamba_depth_bed // channel: [ val(meta), path(bed)        ]
 }

--- a/subworkflows/local/qc_aligned_reads/main.nf
+++ b/subworkflows/local/qc_aligned_reads/main.nf
@@ -21,8 +21,8 @@ workflow QC_ALIGNED_READS {
         ch_bam_bai
     )
 
-    ch_mosdepth_in = ch_bam_bai.combine(ch_mosdepth_bed.map { _meta, bed -> bed }.toList())
     // toList() enables passing [] if ch_bed is empty
+    ch_mosdepth_in = ch_bam_bai.combine(ch_mosdepth_bed.map { _meta, bed -> bed }.toList())
 
     MOSDEPTH(
         ch_mosdepth_in,

--- a/subworkflows/local/qc_phasing/main.nf
+++ b/subworkflows/local/qc_phasing/main.nf
@@ -5,13 +5,13 @@ include { TABIX_BGZIPTABIX } from '../../../modules/nf-core/tabix/bgziptabix/mai
 
 workflow QC_PHASING {
     take:
-    ch_phased_family_snvs     // channel: [ val(meta), path(vcf) ]
+    ch_phased_family_snvs // channel: [ val(meta), path(vcf) ]
     ch_phased_family_snvs_tbi // channel: [ val(meta), path(tbi) ]
-    ch_phased_family_svs      // channel: [ val(meta), path(vcf) ] Optional
-    ch_phased_family_svs_tbi  // channel: [ val(meta), path(tbi) ] Optional
-    ch_bam_bai_haplotagged    // channel: [ val(meta), path(bam), path(bai) ]
-    ch_family_to_samples      // channel: [ val(family_id), val(list_of_sample_ids) ]
-    phase_with_svs            // bool: Whether SVs were included in phasing (true) or not (false)
+    ch_phased_family_svs // channel: [ val(meta), path(vcf) ] Optional
+    ch_phased_family_svs_tbi // channel: [ val(meta), path(tbi) ] Optional
+    ch_bam_bai_haplotagged // channel: [ val(meta), path(bam), path(bai) ]
+    ch_family_to_samples // channel: [ val(family_id), val(list_of_sample_ids) ]
+    phase_with_svs // bool: Whether SVs were included in phasing (true) or not (false)
 
     main:
     // If we co-phased SVs, concatenate SNV and SV VCFs to get accurate stats from WhatsHap
@@ -50,18 +50,17 @@ workflow QC_PHASING {
 
     TABIX_BGZIPTABIX(WHATSHAP_STATS.out.gtf)
 
-    ch_phasing_gtf = TABIX_BGZIPTABIX.out.gz_index
-        .multiMap { meta, gtf, index ->
-            gz: [meta, gtf]
-            tbi: [meta, index]
-        }
+    ch_phasing_gtf = TABIX_BGZIPTABIX.out.gz_index.multiMap { meta, gtf, index ->
+        gz: [meta, gtf]
+        tbi: [meta, index]
+    }
 
     CRAMINO(ch_bam_bai_haplotagged)
 
     emit:
     phasing_stats        = WHATSHAP_STATS.out.tsv // channel: [ val(meta), path(stats) ]
-    phasing_blocks       = ch_phasing_gtf.gz      // channel: [ val(meta), path(gtf)   ]
-    phasing_blocks_index = ch_phasing_gtf.tbi     // channel: [ val(meta), path(tbi)   ]
-    haplotagging_stats   = CRAMINO.out.stats      // channel: [ val(meta), path(txt)   ]
-    haplotagging_arrow   = CRAMINO.out.arrow      // channel: [ val(meta), path(arrow) ]
+    phasing_blocks       = ch_phasing_gtf.gz // channel: [ val(meta), path(gtf)   ]
+    phasing_blocks_index = ch_phasing_gtf.tbi // channel: [ val(meta), path(tbi)   ]
+    haplotagging_stats   = CRAMINO.out.stats // channel: [ val(meta), path(txt)   ]
+    haplotagging_arrow   = CRAMINO.out.arrow // channel: [ val(meta), path(arrow) ]
 }

--- a/subworkflows/local/qc_snvs/main.nf
+++ b/subworkflows/local/qc_snvs/main.nf
@@ -6,9 +6,9 @@ include { BCFTOOLS_STATS             } from '../../../modules/nf-core/bcftools/s
 
 workflow QC_SNVS {
     take:
-    ch_vcf                         // channel: [mandatory] [ val(meta), path(vcf) ]
-    ch_normalized_vcf              // channel: [mandatory] [ val(meta), path(vcf) ]
-    ch_normalized_index            // channel: [mandatory] [ val(meta), path(vcf) ]
+    ch_vcf // channel: [mandatory] [ val(meta), path(vcf) ]
+    ch_normalized_vcf // channel: [mandatory] [ val(meta), path(vcf) ]
+    ch_normalized_index // channel: [mandatory] [ val(meta), path(vcf) ]
     run_deepvariant_vcfstatsreport // value: bool
 
     main:
@@ -34,6 +34,6 @@ workflow QC_SNVS {
     )
 
     emit:
-    vcfstatsreport = ch_vcfstatsreport        // channel: [ val(meta), path(html) ]
+    vcfstatsreport = ch_vcfstatsreport // channel: [ val(meta), path(html) ]
     stats          = BCFTOOLS_STATS.out.stats // channel: [ val(meta), path(txt) ]
 }

--- a/subworkflows/local/rank_variants/main.nf
+++ b/subworkflows/local/rank_variants/main.nf
@@ -10,18 +10,17 @@ include { BCFTOOLS_SORT   } from '../../../modules/nf-core/bcftools/sort/main'
 
 workflow RANK_VARIANTS {
     take:
-    ch_vcf                       // channel: [mandatory] [ val(meta), path(vcf) ]
-    ch_ped                       // channel: [mandatory] [ val(meta), path(ped) ]
+    ch_vcf // channel: [mandatory] [ val(meta), path(vcf) ]
+    ch_ped // channel: [mandatory] [ val(meta), path(ped) ]
     ch_genmod_reduced_penetrance // channel: [mandatory] [ val(meta), path(penetrance) ]
-    ch_score_config              // channel: [mandatory] [ val(meta), path(ini) ]
+    ch_score_config // channel: [mandatory] [ val(meta), path(ini) ]
 
     main:
     GENMOD_ANNOTATE(
         ch_vcf
     )
 
-    ch_genmod_models_in = GENMOD_ANNOTATE.out.vcf
-        .join(ch_ped, failOnMismatch: true, failOnDuplicate: true)
+    ch_genmod_models_in = GENMOD_ANNOTATE.out.vcf.join(ch_ped, failOnMismatch: true, failOnDuplicate: true)
 
     GENMOD_MODELS(
         ch_genmod_models_in,
@@ -33,7 +32,7 @@ workflow RANK_VARIANTS {
         .join(ch_score_config, failOnMismatch: true, failOnDuplicate: true)
 
     GENMOD_SCORE(
-        ch_genmod_score_in,
+        ch_genmod_score_in
     )
 
     GENMOD_COMPOUND(

--- a/subworkflows/local/scatter_genome/main.nf
+++ b/subworkflows/local/scatter_genome/main.nf
@@ -44,10 +44,9 @@ workflow SCATTER_GENOME {
     )
 
     // Add meta.genome so we can extract the mitochondrial region from the BED file
-    ch_input_gawk = BEDTOOLS_MERGE.out.bed
-        .flatMap { meta, bed ->
-            [[meta + [genome: "nuclear"], bed], [meta + [genome: "mitochondrial"], bed]]
-        }
+    ch_input_gawk = BEDTOOLS_MERGE.out.bed.flatMap { meta, bed ->
+        [[meta + [genome: "nuclear"], bed], [meta + [genome: "mitochondrial"], bed]]
+    }
 
     // Exctract according to meta.genome, logic is in the config file
     GAWK_EXTRACT_REGIONS(
@@ -56,18 +55,15 @@ workflow SCATTER_GENOME {
         false,
     )
 
-    ch_bed_genomes = GAWK_EXTRACT_REGIONS.out.output
-        .branch { meta, _bed ->
-            mitochondrial: meta.genome == "mitochondrial"
-            nuclear: meta.genome == "nuclear"
-        }
+    ch_bed_genomes = GAWK_EXTRACT_REGIONS.out.output.branch { meta, _bed ->
+        mitochondrial: meta.genome == "mitochondrial"
+        nuclear: meta.genome == "nuclear"
+    }
 
     // Add the bed count to each channel
-    ch_bed_nuclear_intervals = add_bed_count(ch_bed_genomes.nuclear)
-        .map { meta, bed, num_intervals -> [meta + [num_intervals: num_intervals], bed, num_intervals] }
+    ch_bed_nuclear_intervals = add_bed_count(ch_bed_genomes.nuclear).map { meta, bed, num_intervals -> [meta + [num_intervals: num_intervals], bed, num_intervals] }
 
-    ch_bed_mitochondrial_intervals = add_bed_count(ch_bed_genomes.mitochondrial)
-        .map { meta, bed, num_intervals -> [meta + [num_intervals: num_intervals], bed, num_intervals] }
+    ch_bed_mitochondrial_intervals = add_bed_count(ch_bed_genomes.mitochondrial).map { meta, bed, num_intervals -> [meta + [num_intervals: num_intervals], bed, num_intervals] }
 
     // Make bed interval if split_n > 1, otherwise just pass the bed file through
     if (split_n > 1) {
@@ -109,8 +105,8 @@ workflow SCATTER_GENOME {
     }
 
     emit:
-    bed                         = BEDTOOLS_MERGE.out.bed         // channel: [ val(meta), path(bed) ]
-    bed_nuclear_intervals       = ch_bed_nuclear_intervals       // channel: [ val(meta), path(bed), val(num_intervals) ]
+    bed                         = BEDTOOLS_MERGE.out.bed // channel: [ val(meta), path(bed) ]
+    bed_nuclear_intervals       = ch_bed_nuclear_intervals // channel: [ val(meta), path(bed), val(num_intervals) ]
     bed_mitochondrial_intervals = ch_bed_mitochondrial_intervals // channel: [ val(meta), path(bed), val(num_intervals) ]
 }
 

--- a/subworkflows/local/split_multisample_vcf/main.nf
+++ b/subworkflows/local/split_multisample_vcf/main.nf
@@ -3,7 +3,7 @@ include { BCFTOOLS_VIEW } from '../../../modules/nf-core/bcftools/view/main'
 // Splits mutli-sample VCFs into single-sample VCFs
 workflow SPLIT_MULTISAMPLE_VCF {
     take:
-    ch_vcf_vartype       // channel: [ val(meta), path(vcf), val(variant_type) ]
+    ch_vcf_vartype // channel: [ val(meta), path(vcf), val(variant_type) ]
     ch_family_to_samples // channel: [ val(meta), val(list_of_sample_ids) ]
 
     main:
@@ -21,10 +21,9 @@ workflow SPLIT_MULTISAMPLE_VCF {
         [],
     )
 
-    ch_split_vcf = BCFTOOLS_VIEW.out.vcf
-        .map { meta, vcf ->
-            [meta.subMap(['id', 'family_id']), vcf, meta.variant_type]
-        }
+    ch_split_vcf = BCFTOOLS_VIEW.out.vcf.map { meta, vcf ->
+        [meta.subMap(['id', 'family_id']), vcf, meta.variant_type]
+    }
 
     emit:
     split_vcf = ch_split_vcf // channel: [ val(meta), path(vcf), val(variant_type) ]

--- a/subworkflows/local/utils_nfcore_nallo_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_nallo_pipeline/main.nf
@@ -25,13 +25,13 @@ include { UTILS_NEXTFLOW_PIPELINE } from '../../nf-core/utils_nextflow_pipeline'
 
 workflow PIPELINE_INITIALISATION {
     take:
-    help              // boolean: Display help message and exit
-    help_full         // boolean: Show the full help message
-    monochrome_logs   // boolean: Do not use coloured log outputs
+    help // boolean: Display help message and exit
+    help_full // boolean: Show the full help message
+    monochrome_logs // boolean: Do not use coloured log outputs
     nextflow_cli_args // array: List of positional nextflow CLI args
-    outdir            // string: The output directory where the results will be saved
-    show_hidden       // boolean: Show hidden parameters in the help message
-    validate_params   // boolean: Boolean whether to validate parameters against the schema at runtime
+    outdir // string: The output directory where the results will be saved
+    show_hidden // boolean: Show hidden parameters in the help message
+    validate_params // boolean: Boolean whether to validate parameters against the schema at runtime
     val_cnv_excluded_regions
     val_cnv_expected_xx_cn
     val_cnv_expected_xy_cn
@@ -152,52 +152,52 @@ workflow PIPELINE_INITIALISATION {
     // Define subworkflows and their associated "--skip"
     //
     def workflowSkips = [
-        annotate_paralogs     : "skip_annotate_paralogs",
-        assembly              : "skip_genome_assembly",
-        sambamba_depth        : "skip_sambamba_depth",
-        mapping               : "skip_alignment",
-        snv_calling           : "skip_snv_calling",
-        snv_annotation        : "skip_snv_annotation",
-        sv_calling            : "skip_sv_calling",
-        sv_annotation         : "skip_sv_annotation",
-        call_paralogs         : "skip_call_paralogs",
-        peddy                 : "skip_peddy",
-        phasing               : "skip_phasing",
-        rank_variants         : "skip_rank_variants",
-        repeat_calling        : "skip_repeat_calling",
-        repeat_annotation     : "skip_repeat_annotation",
-        chromograph           : "skip_chromograph",
-        methylation           : "skip_methylation_calling",
+        annotate_paralogs: "skip_annotate_paralogs",
+        assembly: "skip_genome_assembly",
+        sambamba_depth: "skip_sambamba_depth",
+        mapping: "skip_alignment",
+        snv_calling: "skip_snv_calling",
+        snv_annotation: "skip_snv_annotation",
+        sv_calling: "skip_sv_calling",
+        sv_annotation: "skip_sv_annotation",
+        call_paralogs: "skip_call_paralogs",
+        peddy: "skip_peddy",
+        phasing: "skip_phasing",
+        rank_variants: "skip_rank_variants",
+        repeat_calling: "skip_repeat_calling",
+        repeat_annotation: "skip_repeat_annotation",
+        chromograph: "skip_chromograph",
+        methylation: "skip_methylation_calling",
         methylation_annotation: "skip_methylation_annotation",
-        mitochondrial         : "skip_mitochondrial_calling",
-        qc                    : "skip_qc",
-        gens                  : "skip_prepare_gens_input",
-        sex_check             : "skip_sex_check",
+        mitochondrial: "skip_mitochondrial_calling",
+        qc: "skip_qc",
+        gens: "skip_prepare_gens_input",
+        sex_check: "skip_sex_check",
     ]
 
     //
     //  E.g., the CNV-calling workflow depends on mapping and snv_calling and can't run without them.
     //
     def workflowDependencies = [
-        call_paralogs         : ["mapping"],
-        chromograph           : ["mapping"],
-        snv_calling           : ["mapping"],
-        qc                    : ["mapping"],
-        sambamba_depth        : ["mapping"],
-        sex_check             : ["mapping"],
-        sv_calling            : ["mapping"],
-        annotate_paralogs     : ["mapping", "call_paralogs"],
-        sv_annotation         : ["mapping", "sv_calling"],
-        peddy                 : ["mapping", "snv_calling"],
-        snv_annotation        : ["mapping", "snv_calling"],
-        phasing               : ["mapping", "snv_calling"],
-        rank_variants         : ["mapping", "snv_calling", "snv_annotation", "sv_annotation"],
-        repeat_calling        : ["mapping", "snv_calling", "phasing"],
-        repeat_annotation     : ["mapping", "snv_calling", "phasing", "repeat_calling"],
-        methylation           : ["mapping", "snv_calling"],
+        call_paralogs: ["mapping"],
+        chromograph: ["mapping"],
+        snv_calling: ["mapping"],
+        qc: ["mapping"],
+        sambamba_depth: ["mapping"],
+        sex_check: ["mapping"],
+        sv_calling: ["mapping"],
+        annotate_paralogs: ["mapping", "call_paralogs"],
+        sv_annotation: ["mapping", "sv_calling"],
+        peddy: ["mapping", "snv_calling"],
+        snv_annotation: ["mapping", "snv_calling"],
+        phasing: ["mapping", "snv_calling"],
+        rank_variants: ["mapping", "snv_calling", "snv_annotation", "sv_annotation"],
+        repeat_calling: ["mapping", "snv_calling", "phasing"],
+        repeat_annotation: ["mapping", "snv_calling", "phasing", "repeat_calling"],
+        methylation: ["mapping", "snv_calling"],
         methylation_annotation: ["mapping", "snv_calling", "methylation"],
-        mitochondrial         : ["mapping"],
-        gens                  : ["mapping", "snv_calling"],
+        mitochondrial: ["mapping"],
+        gens: ["mapping", "snv_calling"],
     ]
 
 
@@ -205,69 +205,66 @@ workflow PIPELINE_INITIALISATION {
     // E.g., the par_regions file is required by the assembly workflow and the assembly workflow can't run without par_regions
     //
     def fileDependencies = [
-        mapping          : ["fasta"],
-        assembly         : ["fasta"], // The assembly workflow should perhaps be split into two - assembly and alignment (requires ref)
-        sambamba_depth   : ["sambamba_regions"],
-        snv_calling      : ["fasta", "par_regions"],
-        snv_annotation   : ["vep_cache", "vep_plugin_files", "variant_consequences_snvs"],
-        sv_calling       : ["fasta"],
-        sv_annotation    : ["svdb_sv_databases", "vep_cache", "vep_plugin_files", "variant_consequences_svs"],
-        rank_variants    : ["genmod_reduced_penetrance", "genmod_score_config_snvs", "genmod_score_config_svs"],
-        repeat_calling   : ["str_bed"],
+        mapping: ["fasta"],
+        assembly: ["fasta"],
+        sambamba_depth: ["sambamba_regions"],
+        snv_calling: ["fasta", "par_regions"],
+        snv_annotation: ["vep_cache", "vep_plugin_files", "variant_consequences_snvs"],
+        sv_calling: ["fasta"],
+        sv_annotation: ["svdb_sv_databases", "vep_cache", "vep_plugin_files", "variant_consequences_svs"],
+        rank_variants: ["genmod_reduced_penetrance", "genmod_score_config_snvs", "genmod_score_config_svs"],
+        repeat_calling: ["str_bed"],
         repeat_annotation: ["stranger_repeat_catalog"],
-        gens             : ["gens_baf_positions", "gens_panel_of_normals_female", "gens_panel_of_normals_male", "gens_coverage_bins"],
-        sex_check        : ["somalier_sites"],
+        gens: ["gens_baf_positions", "gens_panel_of_normals_female", "gens_panel_of_normals_male", "gens_coverage_bins"],
+        sex_check: ["somalier_sites"],
     ]
 
-    def parameterStatus = [
-        workflow: [
-            skip_annotate_paralogs      : val_skip_annotate_paralogs,
-            skip_snv_calling            : val_skip_snv_calling,
-            skip_peddy                  : val_skip_peddy,
-            skip_phasing                : val_skip_phasing,
-            skip_methylation_calling    : val_skip_methylation_calling,
-            skip_methylation_annotation : val_skip_methylation_annotation,
-            skip_mitochondrial_calling  : val_skip_mitochondrial_calling,
-            skip_rank_variants          : val_skip_rank_variants,
-            skip_repeat_calling         : val_skip_repeat_calling,
-            skip_repeat_annotation      : val_skip_repeat_annotation,
-            skip_chromograph            : val_skip_chromograph,
-            skip_sambamba_depth         : val_skip_sambamba_depth,
-            skip_snv_annotation         : val_skip_snv_annotation,
-            skip_sv_calling             : val_skip_sv_calling,
-            skip_sv_annotation          : val_skip_sv_annotation,
-            skip_call_paralogs          : val_skip_call_paralogs,
-            skip_alignment              : val_skip_alignment,
-            skip_qc                     : val_skip_qc,
-            skip_genome_assembly        : val_skip_genome_assembly,
-            skip_prepare_gens_input     : val_skip_prepare_gens_input,
-            skip_sex_check              : val_skip_sex_check,
-        ],
-        files: [
-            par_regions                 : val_par_regions,
-            echtvar_snv_databases       : val_echtvar_snv_databases,
-            sambamba_regions            : val_sambamba_regions,
-            svdb_sv_databases           : val_svdb_sv_databases,
-            somalier_sites              : val_somalier_sites,
-            vep_cache                   : val_vep_cache,
-            cnv_expected_xy_cn          : val_cnv_expected_xy_cn,
-            cnv_expected_xx_cn          : val_cnv_expected_xx_cn,
-            cnv_excluded_regions        : val_cnv_excluded_regions,
-            fasta                       : val_fasta,
-            str_bed                     : val_str_bed,
-            stranger_repeat_catalog     : val_stranger_repeat_catalog,
-            genmod_reduced_penetrance   : val_genmod_reduced_penetrance,
-            genmod_score_config_snvs    : val_genmod_score_config_snvs,
-            genmod_score_config_svs     : val_genmod_score_config_svs,
-            variant_consequences_snvs   : val_variant_consequences_snvs,
-            variant_consequences_svs    : val_variant_consequences_svs,
-            vep_plugin_files            : val_vep_plugin_files,
-            gens_baf_positions          : val_gens_baf_positions,
+    def parameterStatus = [workflow: [
+        skip_annotate_paralogs: val_skip_annotate_paralogs,
+        skip_snv_calling: val_skip_snv_calling,
+        skip_peddy: val_skip_peddy,
+        skip_phasing: val_skip_phasing,
+        skip_methylation_calling: val_skip_methylation_calling,
+        skip_methylation_annotation: val_skip_methylation_annotation,
+        skip_mitochondrial_calling: val_skip_mitochondrial_calling,
+        skip_rank_variants: val_skip_rank_variants,
+        skip_repeat_calling: val_skip_repeat_calling,
+        skip_repeat_annotation: val_skip_repeat_annotation,
+        skip_chromograph: val_skip_chromograph,
+        skip_sambamba_depth: val_skip_sambamba_depth,
+        skip_snv_annotation: val_skip_snv_annotation,
+        skip_sv_calling: val_skip_sv_calling,
+        skip_sv_annotation: val_skip_sv_annotation,
+        skip_call_paralogs: val_skip_call_paralogs,
+        skip_alignment: val_skip_alignment,
+        skip_qc: val_skip_qc,
+        skip_genome_assembly: val_skip_genome_assembly,
+        skip_prepare_gens_input: val_skip_prepare_gens_input,
+        skip_sex_check: val_skip_sex_check,
+    ], files: [
+        par_regions: val_par_regions,
+        echtvar_snv_databases: val_echtvar_snv_databases,
+        sambamba_regions: val_sambamba_regions,
+        svdb_sv_databases: val_svdb_sv_databases,
+        somalier_sites: val_somalier_sites,
+        vep_cache: val_vep_cache,
+        cnv_expected_xy_cn: val_cnv_expected_xy_cn,
+        cnv_expected_xx_cn: val_cnv_expected_xx_cn,
+        cnv_excluded_regions: val_cnv_excluded_regions,
+        fasta: val_fasta,
+        str_bed: val_str_bed,
+        stranger_repeat_catalog: val_stranger_repeat_catalog,
+        genmod_reduced_penetrance: val_genmod_reduced_penetrance,
+        genmod_score_config_snvs: val_genmod_score_config_snvs,
+        genmod_score_config_svs: val_genmod_score_config_svs,
+        variant_consequences_snvs: val_variant_consequences_snvs,
+        variant_consequences_svs: val_variant_consequences_svs,
+        vep_plugin_files: val_vep_plugin_files,
+        gens_baf_positions: val_gens_baf_positions,
         gens_panel_of_normals_female: val_gens_panel_of_normals_female,
-            gens_panel_of_normals_male  : val_gens_panel_of_normals_male,
-            gens_coverage_bins          : val_gens_coverage_bins,
-        ]
-    ]
+        gens_panel_of_normals_male: val_gens_panel_of_normals_male,
+        gens_coverage_bins: val_gens_coverage_bins,
+    ]]
 
     //
     // Custom validation for pipeline parameters
@@ -279,15 +276,12 @@ workflow PIPELINE_INITIALISATION {
     //
     // Create channel from input file provided through val_input
     //
-    ch_samplesheet = channel
-        .fromList(
+    ch_samplesheet = channel.fromList(
             samplesheetToList(val_input, "${projectDir}/assets/schema_input.json")
         )
-        // add sample as groupTuple key
         .map { meta, reads ->
             [meta.id, meta, reads]
         }
-        // group by sample
         .groupTuple()
         .map { id_meta_reads ->
             validateUniqueFilenamesPerSample(id_meta_reads)
@@ -338,12 +332,12 @@ workflow PIPELINE_INITIALISATION {
 
 workflow PIPELINE_COMPLETION {
     take:
-    email           //  string: email address
-    email_on_fail   //  string: email address sent on pipeline failure
+    email //  string: email address
+    email_on_fail //  string: email address sent on pipeline failure
     plaintext_email // boolean: Send plain-text email instead of HTML
-    outdir          //    path: Path to output directory where results will be published
+    outdir //    path: Path to output directory where results will be published
     monochrome_logs // boolean: Disable ANSI colour codes in log output
-    multiqc_report  //  string: Path to MultiQC report
+    multiqc_report //  string: Path to MultiQC report
 
     main:
     summary_params = paramsSummaryMap(workflow, parameters_schema: "nextflow_schema.json")
@@ -461,7 +455,6 @@ def extractSoftwareFromTopics(topics_channel) {
     topics_channel.map { toolBlockText ->
         toolBlockText
             .readLines()
-            // Drop process name
             .drop(1)
             .collect { line -> line.trim().split(':')[0] }
     }
@@ -470,9 +463,7 @@ def extractSoftwareFromTopics(topics_channel) {
 def generateReferenceHTML(tool_list, description) {
     def items = tool_list
         .collect { citation -> citation.trim() }
-        // e.g. samtools and bcftools share citation
         .unique()
-        // some tools does not have a citation, e.g. awk, gunzip
         .findAll { citation -> citation != "" }
 
     if (description == 'citation') {
@@ -492,7 +483,6 @@ def citationBibliographyText(ch_topic_versions_string, references_yaml, descript
     def baseTools = channel.from(['nextflow', 'nf_core', 'bioconda', 'biocontainers', 'multiqc'])
 
     extractSoftwareFromTopics(ch_topic_versions_string)
-        // split multi-tool modules
         .flatten()
         .unique()
         .filter { tool -> !unwantedReferences.contains(tool) }
@@ -540,7 +530,7 @@ def validateParameterCombinations(statusMap, workflowMap, workflowDependencies, 
 //
 // Lookup all workflows that needs to be active for another workflow
 //
-def checkWorkflowDependencies(String skip, Map combinationsMap, Map statusMap, Map workflowMap, List errors) {
+def checkWorkflowDependencies(skip: String, combinationsMap: Map, statusMap: Map, workflowMap: Map, errors: List) {
 
     // Lookup the workflow associated with the --skip_xxx parameter
     def currentWorkflow = workflowMap.find { _key, mapValue -> mapValue == skip }?.key
@@ -572,7 +562,7 @@ def checkWorkflowDependencies(String skip, Map combinationsMap, Map statusMap, M
 //
 // Lookup if a file is required by any workflows, and add to errors
 //
-def checkFileDependencies(String file, Map combinationsMap, Map statusMap, Map workflowMap, List errors) {
+def checkFileDependencies(file: String, combinationsMap: Map, statusMap: Map, workflowMap: Map, errors: List) {
     // Get all workflows required by a file
     def workflowThatRequiresFile = findKeysForValue(file, combinationsMap)
 
@@ -595,7 +585,7 @@ def checkFileDependencies(String file, Map combinationsMap, Map statusMap, Map w
 //
 // Find the workflow skips that are not currently active
 //
-def findRequiredSkips(paramType, Set<String> requiredWorkflows, Map statusMap, Map workflowMap) {
+def findRequiredSkips(paramType, requiredWorkflows: Set<String>, statusMap: Map, workflowMap: Map) {
 
     def requiredSkips = []
 
@@ -614,7 +604,7 @@ def findRequiredSkips(paramType, Set<String> requiredWorkflows, Map statusMap, M
     return requiredSkips
 }
 
-def findKeysForValue(def valueToFind, Map map) {
+def findKeysForValue(valueToFind, map: Map) {
 
     def keys = []
 
@@ -642,12 +632,12 @@ def createReferenceChannelFromSamplesheet(param, schema, defaultValue = '') {
 
 def validatePacBioLicense(val_phaser, val_str_caller, val_sv_callers, val_sv_callers_to_run, val_sv_callers_to_merge, val_skip_call_paralogs, val_mitochondrial_caller) {
     def pacbioTools = [
-        (val_phaser)              : 'HiPhase',
-        (val_str_caller)          : 'TRGT',
-        (val_sv_callers)          : 'Sawfish',
-        (val_sv_callers_to_run)   : 'Sawfish',
-        (val_sv_callers_to_merge) : 'Sawfish',
-        (!val_skip_call_paralogs) : 'Paraphase',
+        (val_phaser): 'HiPhase',
+        (val_str_caller): 'TRGT',
+        (val_sv_callers): 'Sawfish',
+        (val_sv_callers_to_run): 'Sawfish',
+        (val_sv_callers_to_merge): 'Sawfish',
+        (!val_skip_call_paralogs): 'Paraphase',
         (val_mitochondrial_caller): 'Mitorsaw',
     ].findAll { k, v -> (k instanceof Boolean) ? k : k.toString().contains(v.toLowerCase()) }.values() as List
 
@@ -885,6 +875,6 @@ def isParent(sample) {
     isMother(sample) || isFather(sample)
 }
 
-def boolean isNonZeroNonEmpty(value) {
+def isNonZeroNonEmpty(value) -> boolean {
     (value instanceof String && value != "" && value != "0") || (value instanceof Number && value != 0)
 }

--- a/subworkflows/local/vcf_concat_norm_variants/main.nf
+++ b/subworkflows/local/vcf_concat_norm_variants/main.nf
@@ -7,9 +7,9 @@ include { VCFEXPRESS                                  } from '../../../modules/n
 //
 workflow VCF_CONCAT_NORM_VARIANTS {
     take:
-    ch_vcfs               // channel: [mandatory] [ val(meta), path(vcf) ]
-    ch_fasta              // channel: [mandatory] [ val(meta), path(fasta) ]
-    variant_caller        // string: variant caller to tag the variants with, e.g. "deepvariant"
+    ch_vcfs // channel: [mandatory] [ val(meta), path(vcf) ]
+    ch_fasta // channel: [mandatory] [ val(meta), path(fasta) ]
+    variant_caller // string: variant caller to tag the variants with, e.g. "deepvariant"
     ch_vcfexpress_prelude // path: [mandatory] lua file
 
     main:
@@ -18,9 +18,9 @@ workflow VCF_CONCAT_NORM_VARIANTS {
     )
 
     // Add caller information to meta so vcfexpress can add the FOUND_IN tag based on sv_caller
-    ch_vcfexpress_input = BCFTOOLS_CONCAT.out.vcf
-        .map { meta, vcf -> [ meta + [ sv_caller: variant_caller ] , vcf ]
-        }
+    ch_vcfexpress_input = BCFTOOLS_CONCAT.out.vcf.map { meta, vcf ->
+        [meta + [sv_caller: variant_caller], vcf]
+    }
 
     VCFEXPRESS(
         ch_vcfexpress_input,
@@ -28,9 +28,9 @@ workflow VCF_CONCAT_NORM_VARIANTS {
     )
 
     // Remove added caller information in meta
-    ch_bcftools_norm_input = VCFEXPRESS.out.vcf
-        .map { meta, vcf -> [ meta - meta.subMap('sv_caller'), vcf, [] ]
-        }
+    ch_bcftools_norm_input = VCFEXPRESS.out.vcf.map { meta, vcf ->
+        [meta - meta.subMap('sv_caller'), vcf, []]
+    }
 
     BCFTOOLS_NORM_SINGLESAMPLE(
         ch_bcftools_norm_input,
@@ -38,7 +38,7 @@ workflow VCF_CONCAT_NORM_VARIANTS {
     )
 
     emit:
-    vcf                 = BCFTOOLS_NORM_SINGLESAMPLE.out.vcf                                         // channel: [ val(meta), path(vcf) ]
+    vcf                 = BCFTOOLS_NORM_SINGLESAMPLE.out.vcf // channel: [ val(meta), path(vcf) ]
     index               = BCFTOOLS_NORM_SINGLESAMPLE.out.tbi.mix(BCFTOOLS_NORM_SINGLESAMPLE.out.csi) // channel: [ val(meta), path(tbi/csi) ]
-    bcftools_concat_vcf = BCFTOOLS_CONCAT.out.vcf                                                    // channel: [ val(meta), path(vcf) ]
+    bcftools_concat_vcf = BCFTOOLS_CONCAT.out.vcf // channel: [ val(meta), path(vcf) ]
 }

--- a/subworkflows/local/vcf_concat_sort_variants/main.nf
+++ b/subworkflows/local/vcf_concat_sort_variants/main.nf
@@ -18,6 +18,6 @@ workflow VCF_CONCAT_SORT_VARIANTS {
     )
 
     emit:
-    vcf   = BCFTOOLS_SORT.out.vcf                            // channel: [ val(meta), path(vcf) ]
+    vcf   = BCFTOOLS_SORT.out.vcf // channel: [ val(meta), path(vcf) ]
     index = BCFTOOLS_SORT.out.tbi.mix(BCFTOOLS_SORT.out.csi) // channel: [ val(meta), path(tbi/csi) ]
 }

--- a/subworkflows/local/whatshap/main.nf
+++ b/subworkflows/local/whatshap/main.nf
@@ -4,12 +4,12 @@ include { WHATSHAP_PHASE    } from '../../../modules/nf-core/whatshap/phase/main
 
 workflow WHATSHAP {
     take:
-    ch_snv_vcf   // channel: [ val(meta), path(vcf) ]
+    ch_snv_vcf // channel: [ val(meta), path(vcf) ]
     ch_snv_index // channel: [ val(meta), path(tbi) ]
-    ch_bam_bai   // channel: [ val(meta), path(bam), path(bai) ]
-    fasta        // channel: [ val(meta), path(fasta) ]
-    fai          // channel: [ val(meta), path(fai) ]
-    ch_pedigree  // channel: [ val(meta), path(pedigree) ]
+    ch_bam_bai // channel: [ val(meta), path(bam), path(bai) ]
+    fasta // channel: [ val(meta), path(fasta) ]
+    fai // channel: [ val(meta), path(fai) ]
+    ch_pedigree // channel: [ val(meta), path(pedigree) ]
 
     main:
     // Fix metadata to group by family
@@ -56,8 +56,7 @@ workflow WHATSHAP {
         WHATSHAP_HAPLOTAG.out.bam
     )
 
-    ch_bam_bai_haplotagged = WHATSHAP_HAPLOTAG.out.bam
-        .join(SAMTOOLS_INDEX.out.index, failOnMismatch: true, failOnDuplicate: true)
+    ch_bam_bai_haplotagged = WHATSHAP_HAPLOTAG.out.bam.join(SAMTOOLS_INDEX.out.index, failOnMismatch: true, failOnDuplicate: true)
 
     emit:
     phased_family_snvs     = WHATSHAP_PHASE.out.vcf // channel: [ val(meta), path(vcf) ]

--- a/workflows/nallo.nf
+++ b/workflows/nallo.nf
@@ -255,8 +255,7 @@ workflow NALLO {
         )
 
         // contains all FASTQ files, including those not converted
-        ch_genome_assembly_input = CONVERT_INPUT_BAMS.out.fastq
-            .groupTuple()
+        ch_genome_assembly_input = CONVERT_INPUT_BAMS.out.fastq.groupTuple()
 
         // Hifiasm assembly
         GENOME_ASSEMBLY(
@@ -355,8 +354,7 @@ workflow NALLO {
 
         SAMPLESHEET_PED(ch_samplesheet_ped_in)
 
-        ch_samplesheet_pedfile = SAMPLESHEET_PED.out.ped
-            .collect()
+        ch_samplesheet_pedfile = SAMPLESHEET_PED.out.ped.collect()
 
         if (!val_skip_sex_check) {
             //
@@ -443,10 +441,8 @@ workflow NALLO {
             val_snv_calling_processes,
         )
 
-        ch_bed_intervals = SCATTER_GENOME.out.bed_nuclear_intervals
-            .map { meta, bed, num_intervals -> [meta + [caller: val_snv_caller], bed, num_intervals] }
-        ch_mitochondrial_bed = SCATTER_GENOME.out.bed_mitochondrial_intervals
-            .map { meta, bed, _num_intervals -> [meta, bed] }
+        ch_bed_intervals = SCATTER_GENOME.out.bed_nuclear_intervals.map { meta, bed, num_intervals -> [meta + [caller: val_snv_caller], bed, num_intervals] }
+        ch_mitochondrial_bed = SCATTER_GENOME.out.bed_mitochondrial_intervals.map { meta, bed, _num_intervals -> [meta, bed] }
 
         def ch_num_intervals = ch_bed_intervals.map { _meta, _bed, num_intervals -> num_intervals }.first()
 
@@ -471,11 +467,13 @@ workflow NALLO {
                     vcf: [meta + [caller: val_mitochondrial_caller, genome: 'mitochondrial', num_intervals: num_intervals + 1], vcf]
                     index: [meta + [caller: val_mitochondrial_caller, genome: 'mitochondrial', num_intervals: num_intervals + 1], tbi]
                 }
-        } else {
-            ch_mitochondrial = channel.empty().multiMap { it ->
-                vcf: it
-                index: it
-            }
+        }
+        else {
+            ch_mitochondrial = channel.empty()
+                .multiMap { it ->
+                    vcf: it
+                    index: it
+                }
         }
 
         // Combine the BED intervals with BAM/BAI files to create a region-bam-bai for each sample.
@@ -511,10 +509,9 @@ workflow NALLO {
                 def num_intervals = val_skip_mitochondrial_calling ? meta.num_intervals : meta.num_intervals + 1
                 [[id: meta.region.name, family_id: meta.family_id, genome: meta.genome, num_intervals: num_intervals, caller: val_snv_caller], gvcf, index]
             }
-            .mix(ch_mitochondrial.vcf
-                    .join(ch_mitochondrial.index, failOnMismatch: true, failOnDuplicate: true)
-                    .map { meta, vcf, tbi ->
-                    [[id: meta.genome, family_id: meta.family_id, genome: meta.genome, num_intervals: meta.num_intervals , caller: meta.caller], vcf, tbi]
+            .mix(
+                ch_mitochondrial.vcf.join(ch_mitochondrial.index, failOnMismatch: true, failOnDuplicate: true).map { meta, vcf, tbi ->
+                    [[id: meta.genome, family_id: meta.family_id, genome: meta.genome, num_intervals: meta.num_intervals, caller: meta.caller], vcf, tbi]
                 }
             )
             .groupTuple()
@@ -571,8 +568,7 @@ workflow NALLO {
         family_snv_vcf = GVCF_GLNEXUS_NORM_VARIANTS.out.vcf
         family_snv_index = GVCF_GLNEXUS_NORM_VARIANTS.out.index
 
-        ch_snvs_per_family_unannotated_vcf_tbi = family_snv_vcf
-            .join(family_snv_index, failOnMismatch: true, failOnDuplicate: true)
+        ch_snvs_per_family_unannotated_vcf_tbi = family_snv_vcf.join(family_snv_index, failOnMismatch: true, failOnDuplicate: true)
     }
 
     if (!val_skip_prepare_gens_input) {
@@ -588,8 +584,7 @@ workflow NALLO {
             ch_gvcfs
         )
 
-        ch_gvcf_tbi = CONCAT_SORT_GENS.out.vcf
-            .join(CONCAT_SORT_GENS.out.index)
+        ch_gvcf_tbi = CONCAT_SORT_GENS.out.vcf.join(CONCAT_SORT_GENS.out.index)
 
         PREPARE_GENS_INPUTS(
             ch_bam_bai,
@@ -663,8 +658,7 @@ workflow NALLO {
 
         // Provide a PED file to let whatshap activate pedigree phasing
         // Or pass 'empty_PED' if 'whatshap_pedigree_phasing==false'
-        ch_ped_family = SOMALIER_PED_FAMILY.out.ped
-            .map { meta, ped -> [[id: meta.id], val_whatshap_pedigree_phasing ? ped : []] }
+        ch_ped_family = SOMALIER_PED_FAMILY.out.ped.map { meta, ped -> [[id: meta.id], val_whatshap_pedigree_phasing ? ped : []] }
 
         // Input is one VCF per family with all the regions (except chrM) and all the samples in the family
         PHASING(
@@ -706,8 +700,7 @@ workflow NALLO {
             .join(BCFTOOLS_VIEW_PHASING.out.tbi, failOnMismatch: true, failOnDuplicate: true)
             .map { meta, vcf, tbi -> [meta + [num_intervals: val_skip_mitochondrial_calling ? meta.num_intervals : meta.num_intervals + 1], vcf, tbi] }
 
-        ch_snv_vcf_tbi_mitochondrial_for_annotation = ch_snvs_per_family_unannotated_vcf_tbi
-            .filter { meta, _vcf, _tbi -> meta.genome == "mitochondrial" }
+        ch_snv_vcf_tbi_mitochondrial_for_annotation = ch_snvs_per_family_unannotated_vcf_tbi.filter { meta, _vcf, _tbi -> meta.genome == "mitochondrial" }
 
         ch_snv_vcf_tbi_nuclear_mitochondrial_for_annotation = ch_snv_vcf_tbi_nuclear_for_annotation
             .mix(ch_snv_vcf_tbi_mitochondrial_for_annotation)
@@ -721,14 +714,14 @@ workflow NALLO {
         ch_sv_index_for_annotation = PHASING.out.phased_family_svs_tbi
     }
     else {
-        ch_snv_vcf_tbi_nuclear_mitochondrial_for_annotation   = val_skip_snv_calling ? channel.empty() : family_snv_vcf
-            .join(family_snv_index, failOnMismatch: true, failOnDuplicate: true)
-            .multiMap { meta, vcf, tbi ->
+        ch_snv_vcf_tbi_nuclear_mitochondrial_for_annotation = val_skip_snv_calling
+            ? channel.empty()
+            : family_snv_vcf.join(family_snv_index, failOnMismatch: true, failOnDuplicate: true).multiMap { meta, vcf, tbi ->
                 vcf: [meta, vcf]
                 index: [meta, tbi]
             }
-        ch_sv_vcf_for_annotation    = val_skip_sv_calling  ? channel.empty() : CALL_SVS.out.family_vcf
-        ch_sv_index_for_annotation  = val_skip_sv_calling  ? channel.empty() : CALL_SVS.out.family_tbi
+        ch_sv_vcf_for_annotation = val_skip_sv_calling ? channel.empty() : CALL_SVS.out.family_vcf
+        ch_sv_index_for_annotation = val_skip_sv_calling ? channel.empty() : CALL_SVS.out.family_tbi
     }
 
     // Annotate SNVs
@@ -751,11 +744,10 @@ workflow NALLO {
             val_pre_vep_snv_filter_expression != '',
         )
 
-        ch_clin_research_snvs_vcf = ANNOTATE_SNVS.out.vcf
-            .multiMap { meta, vcf ->
-                clinical: [meta + [set: "clinical"], vcf]
-                research: [meta + [set: "research"], vcf]
-            }
+        ch_clin_research_snvs_vcf = ANNOTATE_SNVS.out.vcf.multiMap { meta, vcf ->
+            clinical: [meta + [set: "clinical"], vcf]
+            research: [meta + [set: "research"], vcf]
+        }
 
         ch_ann_csq_pli_snv_in = ch_clin_research_snvs_vcf.research
 
@@ -777,8 +769,7 @@ workflow NALLO {
             ch_variant_consequences_snvs,
         )
 
-        ch_snvs_per_family_annotated_vcf_tbi = ANN_CSQ_PLI_SNV.out.vcf
-            .join(ANN_CSQ_PLI_SNV.out.tbi, failOnMismatch: true, failOnDuplicate: true)
+        ch_snvs_per_family_annotated_vcf_tbi = ANN_CSQ_PLI_SNV.out.vcf.join(ANN_CSQ_PLI_SNV.out.tbi, failOnMismatch: true, failOnDuplicate: true)
     }
 
     //
@@ -831,8 +822,7 @@ workflow NALLO {
 
         if (!val_skip_snv_annotation) {
             // Use already concatenated VCFs
-            ch_peddy_in = CONCAT_SORT_ANNOTATED_SNVS.out.vcf
-                .join(CONCAT_SORT_ANNOTATED_SNVS.out.index, failOnMismatch: true, failOnDuplicate: true)
+            ch_peddy_in = CONCAT_SORT_ANNOTATED_SNVS.out.vcf.join(CONCAT_SORT_ANNOTATED_SNVS.out.index, failOnMismatch: true, failOnDuplicate: true)
         }
         else {
             // If we did not annotate, we did not concatenate the VCFs before, so we need to do that here.
@@ -845,8 +835,7 @@ workflow NALLO {
                 ch_concat_sort_peddy_in
             )
 
-            ch_peddy_in = CONCAT_SORT_PEDDY.out.vcf
-                .join(CONCAT_SORT_PEDDY.out.index, failOnMismatch: true, failOnDuplicate: true)
+            ch_peddy_in = CONCAT_SORT_PEDDY.out.vcf.join(CONCAT_SORT_PEDDY.out.index, failOnMismatch: true, failOnDuplicate: true)
         }
 
         PEDDY(
@@ -888,11 +877,10 @@ workflow NALLO {
             ch_vep_plugin_files.collect(),
         )
 
-        ch_clin_research_svs_vcf = ANNOTATE_SVS.out.vcf
-            .multiMap { meta, vcf ->
-                clinical: [meta + [set: "clinical"], vcf]
-                research: [meta + [set: "research"], vcf]
-            }
+        ch_clin_research_svs_vcf = ANNOTATE_SVS.out.vcf.multiMap { meta, vcf ->
+            clinical: [meta + [set: "clinical"], vcf]
+            research: [meta + [set: "research"], vcf]
+        }
 
         ch_ann_csq_svs_in = ch_clin_research_svs_vcf.research
 


### PR DESCRIPTION
Format all local subworkflows and modules with `nextflow lint -format -harshil-alignment` that will be used in the pre-commit added in https://github.com/genomic-medicine-sweden/nallo/pull/1173. 

### Changed

- Formatted all local subworkflows and modules  with `nextflow lint -format -harshil-alignment`