### PR TITLE
Remove lint ignore for template strings in nf-dev-guidelines config

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -34,8 +34,6 @@ lint:
   nextflow_config:
     - manifest.name
     - manifest.homePage
-  template_strings:
-    - assets/nf-dev-guidelines.yaml
 nf_core_version: 4.0.2
 repository_type: pipeline
 template:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1181](https://github.com/genomic-medicine-sweden/nallo/pull/1181) - Updated minimum nextflow version to 26.04.4
 - [#1182](https://github.com/genomic-medicine-sweden/nallo/pull/1182) - Formatted all config files with `nextflow lint -format -harshil-alignment`
 - [#1183](https://github.com/genomic-medicine-sweden/nallo/pull/1183) - Formatted all local subworkflows and modules with `nextflow lint -format -harshil-alignment`
+- [#1184](https://github.com/genomic-medicine-sweden/nallo/pull/1184) - Update `.nf-core.yml` to remove lint ignore directive for template strings in `assets/nf-dev-guidelines.yaml`.
 
 ### Removed
 


### PR DESCRIPTION
## Description

The config file `assets/nf-dev-guidelines.yaml` does not contain any template strings. Therefore it is not necessary to ignore nf-core linting checks for template strings in this file. See https://github.com/genomic-medicine-sweden/nf-dev-guidelines/pull/35.

### Changed

- Update `.nf-core.yml` to remove lint ignore directive for template strings in `assets/nf-dev-guidelines.yaml`.
