### PR TITLE
Add concatenated haplotypes output to genome_assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1164](https://github.com/genomic-medicine-sweden/nallo/pull/1164) - Added `--skip_mitochondrial_calling` parameter to allow skipping mitochondrial variant calling
 - [#1173](https://github.com/genomic-medicine-sweden/nallo/pull/1173) - Added formatting to pre-commit
 - [#1178](https://github.com/genomic-medicine-sweden/nallo/pull/1178) - Added nextflow lint -format CI check
-- [#1191](https://github.com/genomic-medicine-sweden/nallo/pull/1191) - Added new `concatenated_haplotypes` output to `GENOME_ASSEMBLY`
+- [#1194](https://github.com/genomic-medicine-sweden/nallo/pull/1194) - Added new `concatenated_haplotypes` output to `GENOME_ASSEMBLY`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1155](https://github.com/genomic-medicine-sweden/nallo/pull/1155) - Added Nallo paper to the README
 - [#1164](https://github.com/genomic-medicine-sweden/nallo/pull/1164) - Added `--skip_mitochondrial_calling` parameter to allow skipping mitochondrial variant calling
 - [#1173](https://github.com/genomic-medicine-sweden/nallo/pull/1173) - Added formatting to pre-commit
-- [#1178](https://github.com/genomic-medicine-sweden/nallo/pull/1173) - Added nextflow lint -format CI check
+- [#1178](https://github.com/genomic-medicine-sweden/nallo/pull/1178) - Added nextflow lint -format CI check
+- [#1191](https://github.com/genomic-medicine-sweden/nallo/pull/1191) - Added new `concatenated_haplotypes` output to `GENOME_ASSEMBLY`
 
 ### Changed
 
@@ -130,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | sentieon-cli/dnascope-longread | 1.5.2       | 1.6.2       |
 | hiphase                        | 1.4.0       | 1.6.0       |
 | echtvar/anno                   | 0.2.2       | 0.2.4       |
+| find/concatenate               |             | 4.6.0       |
 
 > [!NOTE]
 > Version has been updated if both old and new version information is present.

--- a/assets/software_references.yml
+++ b/assets/software_references.yml
@@ -195,6 +195,12 @@ tool:
   perl-math-cdf:
     citation: "perl-math-cdf"
     bibliography: ""
+  coreutils:
+    citation: "GNU coreutils"
+    bibliography: ""
+  find:
+    citation: "find/concatenate"
+    bibliography: ""
   mitorsaw:
     citation: "Mitorsaw"
     bibliography: ""

--- a/modules.json
+++ b/modules.json
@@ -169,6 +169,11 @@
                         "git_sha": "79b36b51048048374b642289bfe9e591ef56fe05",
                         "installed_by": ["modules"]
                     },
+                    "find/concatenate": {
+                        "branch": "master",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
+                        "installed_by": ["modules"]
+                    },
                     "gatk4/denoisereadcounts": {
                         "branch": "master",
                         "git_sha": "86308d628760125908c5c77540517effe0f8880f",

--- a/modules/nf-core/find/concatenate/environment.yml
+++ b/modules/nf-core/find/concatenate/environment.yml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - coreutils==9.4
+  - findutils==4.6.0
+  - pigz==2.8

--- a/modules/nf-core/find/concatenate/main.nf
+++ b/modules/nf-core/find/concatenate/main.nf
@@ -1,0 +1,70 @@
+process FIND_CONCATENATE {
+    tag "${meta.id}"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7f/7fd226561e12b32bcacdf4f5ff74577e76233adf52ae5cbc499a2cdfe0e27d82/data'
+        : 'community.wave.seqera.io/library/findutils_pigz:c4dd5edc44402661'}"
+
+    input:
+    tuple val(meta), path(files_in, stageAs: 'to_concatenate/*', arity: '1..*')
+
+    output:
+    tuple val(meta), path("${prefix}"), emit: file_out
+    tuple val("${task.process}"), val("find"), eval("find --version | sed '1!d; s/.* //'"), topic: versions, emit: versions_find
+    tuple val("${task.process}"), val("pigz"), eval("pigz --version 2>&1 | sed 's/pigz //g'"), topic: versions, emit: versions_pigz
+    tuple val("${task.process}"), val("coreutils"), eval("cat --version | sed '1!d; s/.* //'"), topic: versions, emit: versions_coreutils
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ""
+
+    // | input     | output     | command1 | command2 |
+    // |-----------|------------|----------|----------|
+    // | gzipped   | gzipped    | cat      |          |
+    // | ungzipped | ungzipped  | cat      |          |
+    // | gzipped   | ungzipped  | pigz     |          |
+    // | ungzipped | gzipped    | cat      | pigz     |
+
+    // Use input file ending as default
+    // get file extensions, if extension is .gz then get the second to last extension as well
+    file_extensions = files_in.collect { in_file -> in_file.name - in_file.getBaseName(in_file.name.endsWith('.gz') ? 2 : 1) }
+
+    // Use input file ending as default for output file
+    prefix = task.ext.prefix ?: "${meta.id}${file_extensions[0]}"
+
+    if (files_in.any{ file -> file.toString().endsWith('.gz')} && !files_in.every{ file -> file.toString().endsWith('.gz') }) {
+        error("All files provided to this module must either be gzipped (and have the .gz extension) or unzipped (and not have the .gz extension). A mix of both is not allowed.")
+    }
+
+    in_zip = files_in[0].toString().endsWith('.gz')
+    out_zip = task.ext.prefix ? task.ext.prefix.endsWith('.gz') : file_extensions[0].endsWith('.gz')
+
+    out_fname = in_zip && out_zip ? prefix : prefix.endsWith('.gz') ? prefix.replace('.gz', '') : prefix
+
+    cmd1 = in_zip && !out_zip ? "pigz -cd -p ${task.cpus}" : "cat"
+    cmd2 = !in_zip && out_zip ? "pigz -p ${task.cpus} ${args} ${out_fname}" : ""
+
+    """
+    while IFS= read -r -d \$'\\0' file; do
+            ${cmd1} \$file \\
+                >> ${out_fname}
+        done < <( find to_concatenate/ -mindepth 1 -print0 | sort -z )
+
+    ${cmd2}
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+
+    if (files_in.any{ file -> file.toString().endsWith('.gz')} && !files_in.every{ file -> file.toString().endsWith('.gz') }) {
+        error("All files provided to this module must either be gzipped (and have the .gz extension) or unzipped (and not have the .gz extension). A mix of both is not allowed.")
+    }
+
+    """
+    touch ${prefix}
+    """
+}

--- a/modules/nf-core/find/concatenate/meta.yml
+++ b/modules/nf-core/find/concatenate/meta.yml
@@ -1,0 +1,112 @@
+name: "find_concatenate"
+description: A module for concatenation of gzipped or uncompressed files getting around
+  UNIX terminal argument size
+keywords:
+  - concatenate
+  - gzip
+  - cat
+  - find
+  - pigz
+tools:
+  - find:
+      description: GNU find searches the directory tree rooted at each given starting-point
+        by evaluating the given expression
+      documentation: https://man7.org/linux/man-pages/man1/find.1.html
+      licence:
+        - "GPL-3.0-or-later"
+      identifier: ""
+  - pigz:
+      description: pigz, which stands for Parallel Implementation of GZip, is a fully
+        functional replacement for gzip that exploits multiple processors and multiple
+        cores to the hilt when compressing data.
+      documentation: https://zlib.net/pigz/pigz.pdf
+      licence:
+        - "other"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test' ]
+    - files_in:
+        type: file
+        description: List of either compressed or uncompressed files
+        pattern: "*"
+        ontologies: []
+output:
+  file_out:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - ${prefix}:
+          type: file
+          description: Concatenated file. Will be gzipped if ${prefix} ends with ".gz"
+            or inputs are gzipped, will be uncompressed otherwise.
+          pattern: "${file_out}"
+          ontologies: []
+  versions_find:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - find:
+          type: string
+          description: The name of the tool
+      - find --version | sed '1!d; s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_pigz:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - pigz:
+          type: string
+          description: The name of the tool
+      - pigz --version 2>&1 | sed 's/pigz //g':
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_coreutils:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - coreutils:
+          type: string
+          description: The name of the tool
+      - cat --version | sed '1!d; s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - find:
+          type: string
+          description: The name of the tool
+      - find --version | sed '1!d; s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - pigz:
+          type: string
+          description: The name of the tool
+      - pigz --version 2>&1 | sed 's/pigz //g':
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - coreutils:
+          type: string
+          description: The name of the tool
+      - cat --version | sed '1!d; s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@BioWilko"
+maintainers:
+  - "@BioWilko"

--- a/modules/nf-core/find/concatenate/tests/main.nf.test
+++ b/modules/nf-core/find/concatenate/tests/main.nf.test
@@ -1,0 +1,154 @@
+nextflow_process {
+
+    name "Test Process FIND_CONCATENATE"
+    script "../main.nf"
+    process "FIND_CONCATENATE"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "find"
+    tag "find/concatenate"
+
+    test("test_mixed_input") {
+        when {
+            process {
+                """
+                input[0] =
+                    [
+                        [ id:'test', single_end:true ],
+                        [
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true)
+                        ]
+                    ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert !process.success },
+                { assert process.stdout.toString().contains("All files provided to this module must either be gzipped (and have the .gz extension) or unzipped (and not have the .gz extension). A mix of both is not allowed.") },
+            )
+        }
+    }
+
+    test("test_cat_unzipped_unzipped") {
+        when {
+            process {
+                """
+                input[0] =
+                    [
+                        [ id:'test', single_end:true ],
+                        [
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.sizes', checkIfExists: true)
+                        ]
+                    ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() },
+            )
+        }
+    }
+
+
+    test("test_cat_zipped_zipped") {
+        when {
+            process {
+                """
+                input[0] =
+                    [
+                        [ id:'test', single_end:true ],
+                        [
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gff3.gz', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true)
+                        ]
+                    ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() },
+            )
+        }
+    }
+
+    test("test_cat_zipped_unzipped") {
+        config './nextflow_zipped_unzipped.config'
+
+        when {
+            process {
+                """
+                input[0] =
+                    [
+                        [ id:'test', single_end:true ],
+                        [
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gff3.gz', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true)
+                        ]
+                    ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() },
+            )
+        }
+
+    }
+
+    test("test_cat_unzipped_zipped") {
+        config './nextflow_unzipped_zipped.config'
+        when {
+            process {
+                """
+                input[0] =
+                    [
+                        [ id:'test', single_end:true ],
+                        [
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.sizes', checkIfExists: true)
+                        ]
+                    ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() },
+            )
+        }
+    }
+
+    test("test_cat_one_file_unzipped_zipped") {
+        config './nextflow_unzipped_zipped.config'
+        when {
+            process {
+                """
+                input[0] =
+                    [
+                        [ id:'test', single_end:true ],
+                        [
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                        ]
+                    ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() },
+            )
+        }
+    }
+}

--- a/modules/nf-core/find/concatenate/tests/main.nf.test.snap
+++ b/modules/nf-core/find/concatenate/tests/main.nf.test.snap
@@ -1,0 +1,207 @@
+{
+    "test_cat_unzipped_unzipped": {
+        "content": [
+            {
+                "file_out": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fasta:md5,f44b33a0e441ad58b2d3700270e2dbe2"
+                    ]
+                ],
+                "versions_coreutils": [
+                    [
+                        "FIND_CONCATENATE",
+                        "coreutils",
+                        "9.4"
+                    ]
+                ],
+                "versions_find": [
+                    [
+                        "FIND_CONCATENATE",
+                        "find",
+                        "4.6.0"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "FIND_CONCATENATE",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-03-11T11:55:56.090740487"
+    },
+    "test_cat_zipped_zipped": {
+        "content": [
+            {
+                "file_out": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.gff3.gz:md5,1a983f97a01107efe42c8c3e7728b4c1"
+                    ]
+                ],
+                "versions_coreutils": [
+                    [
+                        "FIND_CONCATENATE",
+                        "coreutils",
+                        "9.4"
+                    ]
+                ],
+                "versions_find": [
+                    [
+                        "FIND_CONCATENATE",
+                        "find",
+                        "4.6.0"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "FIND_CONCATENATE",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-03-11T11:56:03.72242729"
+    },
+    "test_cat_zipped_unzipped": {
+        "content": [
+            {
+                "file_out": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "cat.txt:md5,1a983f97a01107efe42c8c3e7728b4c1"
+                    ]
+                ],
+                "versions_coreutils": [
+                    [
+                        "FIND_CONCATENATE",
+                        "coreutils",
+                        "9.4"
+                    ]
+                ],
+                "versions_find": [
+                    [
+                        "FIND_CONCATENATE",
+                        "find",
+                        "4.6.0"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "FIND_CONCATENATE",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-03-11T11:56:11.488401849"
+    },
+    "test_cat_one_file_unzipped_zipped": {
+        "content": [
+            {
+                "file_out": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "cat.txt.gz:md5,6e9fe4042a72f2345f644f239272b7e6"
+                    ]
+                ],
+                "versions_coreutils": [
+                    [
+                        "FIND_CONCATENATE",
+                        "coreutils",
+                        "9.4"
+                    ]
+                ],
+                "versions_find": [
+                    [
+                        "FIND_CONCATENATE",
+                        "find",
+                        "4.6.0"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "FIND_CONCATENATE",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-03-11T11:56:26.254644609"
+    },
+    "test_cat_unzipped_zipped": {
+        "content": [
+            {
+                "file_out": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "cat.txt.gz:md5,f44b33a0e441ad58b2d3700270e2dbe2"
+                    ]
+                ],
+                "versions_coreutils": [
+                    [
+                        "FIND_CONCATENATE",
+                        "coreutils",
+                        "9.4"
+                    ]
+                ],
+                "versions_find": [
+                    [
+                        "FIND_CONCATENATE",
+                        "find",
+                        "4.6.0"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "FIND_CONCATENATE",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-03-11T11:56:18.76821511"
+    }
+}

--- a/modules/nf-core/find/concatenate/tests/nextflow_unzipped_zipped.config
+++ b/modules/nf-core/find/concatenate/tests/nextflow_unzipped_zipped.config
@@ -1,0 +1,5 @@
+process {
+    withName: FIND_CONCATENATE {
+        ext.prefix = 'cat.txt.gz'
+    }
+}

--- a/modules/nf-core/find/concatenate/tests/nextflow_zipped_unzipped.config
+++ b/modules/nf-core/find/concatenate/tests/nextflow_zipped_unzipped.config
@@ -1,0 +1,6 @@
+process {
+
+    withName: FIND_CONCATENATE {
+        ext.prefix = 'cat.txt'
+    }
+}

--- a/subworkflows/local/genome_assembly/main.nf
+++ b/subworkflows/local/genome_assembly/main.nf
@@ -3,6 +3,8 @@ include { HIFIASM as HIFIASM_BINS     } from '../../../modules/nf-core/hifiasm'
 include { HIFIASM as HIFIASM_ASSEMBLY } from '../../../modules/nf-core/hifiasm'
 include { YAK_COUNT                   } from '../../../modules/nf-core/yak/count/main'
 include { GFASTATS                    } from '../../../modules/nf-core/gfastats/main'
+include { FIND_CONCATENATE            } from '../../../modules/nf-core/find/concatenate/main'
+
 
 // This subworkflow assembles and outputs haplotypes from a set of reads (grouped per sample), using hifiasm and gfastats.
 // It assumes that while each sample can have multiple files, each sample belongs to one family at most.
@@ -10,6 +12,7 @@ workflow GENOME_ASSEMBLY {
     take:
     ch_reads // channel: [ val(meta), fastqs ]
     trio_binning // bool: Should we use trio binning mode where possible?
+    concat_assemblies // bool: Should we concatenate haplotypes per sample?
 
     main:
     if (trio_binning) {
@@ -116,7 +119,23 @@ workflow GENOME_ASSEMBLY {
         [[], []],
     )
 
+    if (concat_assemblies) {
+        ch_assemblies_to_concatenate = GFASTATS.out.assembly
+            .map { meta, bam -> [meta - meta.subMap('haplotype'), bam] }
+            .groupTuple(size: 2)
+
+        FIND_CONCATENATE(
+            ch_assemblies_to_concatenate
+        )
+
+        ch_concatenated_haplotypes = FIND_CONCATENATE.out.file_out
+    }
+    else {
+        ch_concatenated_haplotypes = channel.empty()
+    }
+
     emit:
-    assembled_haplotypes = GFASTATS.out.assembly // channel: [ val(meta), path(fasta) ]
-    assembly_summary     = GFASTATS.out.assembly_summary // channel: [ val(meta), path(assembly_summary) ]
+    assembled_haplotypes    = GFASTATS.out.assembly // channel: [ val(meta), path(fasta) ]
+    assembly_summary        = GFASTATS.out.assembly_summary // channel: [ val(meta), path(assembly_summary) ]
+    concatenated_haplotypes = ch_concatenated_haplotypes // channel: [ val(meta), path(assembly_stats) ]
 }

--- a/subworkflows/local/genome_assembly/main.nf
+++ b/subworkflows/local/genome_assembly/main.nf
@@ -137,5 +137,5 @@ workflow GENOME_ASSEMBLY {
     emit:
     assembled_haplotypes    = GFASTATS.out.assembly // channel: [ val(meta), path(fasta) ]
     assembly_summary        = GFASTATS.out.assembly_summary // channel: [ val(meta), path(assembly_summary) ]
-    concatenated_haplotypes = ch_concatenated_haplotypes // channel: [ val(meta), path(assembly_stats) ]
+    concatenated_haplotypes = ch_concatenated_haplotypes // channel: [ val(meta), path(fasta) ]
 }

--- a/subworkflows/local/genome_assembly/tests/main.nf.test
+++ b/subworkflows/local/genome_assembly/tests/main.nf.test
@@ -16,6 +16,7 @@ nextflow_workflow {
                     ]
                 )
                 input[1] = false
+                input[2] = false
                 """
             }
         }
@@ -64,6 +65,7 @@ nextflow_workflow {
                     }
                     .groupTuple()
                 input[1] = true
+                input[2] = false
                 """
             }
         }
@@ -77,7 +79,7 @@ nextflow_workflow {
         }
     }
 
-    test("two children with two parents, trio-binning mode") {
+    test("two children with two parents, trio-binning mode, concatenated_haplotypes output") {
 
         setup {
             run("SAMTOOLS_FASTQ") {
@@ -115,6 +117,7 @@ nextflow_workflow {
                     }
                     .groupTuple()
                 input[1] = true
+                input[2] = true
                 """
             }
         }
@@ -124,7 +127,7 @@ nextflow_workflow {
                 // other than a manual .view() on `ch_with_both_parents`, without adding the
                 // `ch_with_both_parents` intermediate channel to the output.
                 { assert workflow.success },
-                { assert workflow.trace.succeeded().size() == 22 }, // 22 tasks: 4x FASTQ, 2x YAK_COUNT, 4x HIFIASM_BINS, 4x HIFIASM_ASSEMBLY, 8x GFASTATS.
+                { assert workflow.trace.succeeded().size() == 26 }, // 26 tasks: 4x FASTQ, 2x YAK_COUNT, 4x HIFIASM_BINS, 4x HIFIASM_ASSEMBLY, 8x GFASTATS, 4x FIND_CONCATENATE.
                 { assert workflow.out.assembled_haplotypes.size() == 8 },
                 { assert snapshot(workflow.out).match() }
             )
@@ -163,6 +166,7 @@ nextflow_workflow {
                     }
                     .groupTuple()
                 input[1] = true
+                input[2] = false
                 """
             }
         }
@@ -190,6 +194,7 @@ nextflow_workflow {
                     ]
                 )
                 input[1] = false
+                input[2] = false
                 """
             }
         }
@@ -221,6 +226,7 @@ nextflow_workflow {
                 }
                 .groupTuple()
                 input[1] = true
+                input[2] = false
                 """
             }
         }
@@ -234,7 +240,7 @@ nextflow_workflow {
         }
     }
 
-    test("child with two parents, trio-binning mode -stub") {
+    test("child with two parents, trio-binning mode, concatenated_haplotypes output -stub") {
 
         options "-stub"
 
@@ -271,13 +277,14 @@ nextflow_workflow {
                     }
                     .groupTuple()
                 input[1] = true
+                input[2] = true
                 """
             }
         }
         then {
             assertAll(
                 { assert workflow.success },
-                { assert workflow.trace.succeeded().size() == 17 }, // 17 tasks: 3x FASTQ, 2x YAK_COUNT, 3x HIFIASM_BINS, 3x HIFIASM_ASSEMBLY, 6x GFASTATS.
+                { assert workflow.trace.succeeded().size() == 20 }, // 20 tasks: 3x FASTQ, 2x YAK_COUNT, 3x HIFIASM_BINS, 3x HIFIASM_ASSEMBLY, 6x GFASTATS, 3x FIND_CONCATENATE
                 { assert workflow.out.assembled_haplotypes.size() == 6 },
                 { assert snapshot(workflow.out).match() }
             )

--- a/subworkflows/local/genome_assembly/tests/main.nf.test.snap
+++ b/subworkflows/local/genome_assembly/tests/main.nf.test.snap
@@ -42,6 +42,9 @@
                         "test_fastq_haplotype_2.assembly_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "2": [
+                    
+                ],
                 "assembled_haplotypes": [
                     [
                         {
@@ -81,16 +84,19 @@
                         },
                         "test_fastq_haplotype_2.assembly_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
+                ],
+                "concatenated_haplotypes": [
+                    
                 ]
             }
         ],
-        "timestamp": "2026-05-27T11:01:41.153589109",
+        "timestamp": "2026-07-10T11:25:47.336988804",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.02.0"
+            "nextflow": "26.06.0"
         }
     },
-    "two children with two parents, trio-binning mode": {
+    "two children with two parents, trio-binning mode, concatenated_haplotypes output": {
         "content": [
             {
                 "0": [
@@ -329,6 +335,62 @@
                         "second_child_haplotype_2.assembly_summary:md5,7e678db8aee9b69f73378305e7dc9364"
                     ]
                 ],
+                "2": [
+                    [
+                        {
+                            "id": "HG002",
+                            "n_files": 1,
+                            "relationship": "child",
+                            "children": [
+                                
+                            ],
+                            "family_id": "NIST",
+                            "two_parents": true
+                        },
+                        "HG002.fasta.gz:md5,1876115e3a8218d8bb3a14d7a745f5f1"
+                    ],
+                    [
+                        {
+                            "id": "HG003",
+                            "n_files": 1,
+                            "relationship": "father",
+                            "children": [
+                                "HG002",
+                                "second_child"
+                            ],
+                            "family_id": "NIST",
+                            "has_other_parent": true
+                        },
+                        "HG003.fasta.gz:md5,ef0124b3d672ce94f6b463441410f42a"
+                    ],
+                    [
+                        {
+                            "id": "HG004",
+                            "n_files": 1,
+                            "relationship": "mother",
+                            "children": [
+                                "HG002",
+                                "second_child"
+                            ],
+                            "family_id": "NIST",
+                            "has_other_parent": true
+                        },
+                        "HG004.fasta.gz:md5,24bd677663519b1aa570472377c8e126"
+                    ],
+                    [
+                        {
+                            "id": "second_child",
+                            "n_files": 1,
+                            "relationship": "child",
+                            "children": [
+                                
+                            ],
+                            "family_id": "NIST",
+                            "two_parents": true
+                        },
+                        "second_child.fasta.gz:md5,1876115e3a8218d8bb3a14d7a745f5f1"
+                    ]
+                ],
                 "assembled_haplotypes": [
                     [
                         {
@@ -564,13 +626,69 @@
                         },
                         "second_child_haplotype_2.assembly_summary:md5,7e678db8aee9b69f73378305e7dc9364"
                     ]
+                ],
+                "concatenated_haplotypes": [
+                    [
+                        {
+                            "id": "HG002",
+                            "n_files": 1,
+                            "relationship": "child",
+                            "children": [
+                                
+                            ],
+                            "family_id": "NIST",
+                            "two_parents": true
+                        },
+                        "HG002.fasta.gz:md5,1876115e3a8218d8bb3a14d7a745f5f1"
+                    ],
+                    [
+                        {
+                            "id": "HG003",
+                            "n_files": 1,
+                            "relationship": "father",
+                            "children": [
+                                "HG002",
+                                "second_child"
+                            ],
+                            "family_id": "NIST",
+                            "has_other_parent": true
+                        },
+                        "HG003.fasta.gz:md5,ef0124b3d672ce94f6b463441410f42a"
+                    ],
+                    [
+                        {
+                            "id": "HG004",
+                            "n_files": 1,
+                            "relationship": "mother",
+                            "children": [
+                                "HG002",
+                                "second_child"
+                            ],
+                            "family_id": "NIST",
+                            "has_other_parent": true
+                        },
+                        "HG004.fasta.gz:md5,24bd677663519b1aa570472377c8e126"
+                    ],
+                    [
+                        {
+                            "id": "second_child",
+                            "n_files": 1,
+                            "relationship": "child",
+                            "children": [
+                                
+                            ],
+                            "family_id": "NIST",
+                            "two_parents": true
+                        },
+                        "second_child.fasta.gz:md5,1876115e3a8218d8bb3a14d7a745f5f1"
+                    ]
                 ]
             }
         ],
-        "timestamp": "2026-05-27T11:01:16.15759367",
+        "timestamp": "2026-07-10T11:25:13.209345593",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.02.0"
+            "nextflow": "26.06.0"
         }
     },
     "child with one parent, trio-binning mode -stub": {
@@ -692,6 +810,9 @@
                         "HG003_haplotype_2.assembly_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "2": [
+                    
+                ],
                 "assembled_haplotypes": [
                     [
                         {
@@ -807,13 +928,16 @@
                         },
                         "HG003_haplotype_2.assembly_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
+                ],
+                "concatenated_haplotypes": [
+                    
                 ]
             }
         ],
-        "timestamp": "2026-05-27T11:01:24.980558878",
+        "timestamp": "2026-07-10T11:25:26.409784908",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.02.0"
+            "nextflow": "26.06.0"
         }
     },
     "child with two parents, trio-binning mode": {
@@ -991,6 +1115,9 @@
                         "HG004_haplotype_2.assembly_summary:md5,adc271665fb11761203e53773de1215f"
                     ]
                 ],
+                "2": [
+                    
+                ],
                 "assembled_haplotypes": [
                     [
                         {
@@ -1162,13 +1289,16 @@
                         },
                         "HG004_haplotype_2.assembly_summary:md5,adc271665fb11761203e53773de1215f"
                     ]
+                ],
+                "concatenated_haplotypes": [
+                    
                 ]
             }
         ],
-        "timestamp": "2026-05-27T11:00:54.97322628",
+        "timestamp": "2026-07-10T11:24:47.729602239",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.02.0"
+            "nextflow": "26.06.0"
         }
     },
     "one sample, hifi-only mode -stub": {
@@ -1214,6 +1344,9 @@
                         "test_fastq_haplotype_2.assembly_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "2": [
+                    
+                ],
                 "assembled_haplotypes": [
                     [
                         {
@@ -1253,13 +1386,16 @@
                         },
                         "test_fastq_haplotype_2.assembly_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
+                ],
+                "concatenated_haplotypes": [
+                    
                 ]
             }
         ],
-        "timestamp": "2026-05-27T11:01:33.159797716",
+        "timestamp": "2026-07-10T11:25:38.075521227",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.02.0"
+            "nextflow": "26.06.0"
         }
     },
     "one sample, hifi-only mode": {
@@ -1305,6 +1441,9 @@
                         "test_fastq_haplotype_2.assembly_summary:md5,53928ced28326a9fae5f2b8f7d25ea18"
                     ]
                 ],
+                "2": [
+                    
+                ],
                 "assembled_haplotypes": [
                     [
                         {
@@ -1344,16 +1483,19 @@
                         },
                         "test_fastq_haplotype_2.assembly_summary:md5,53928ced28326a9fae5f2b8f7d25ea18"
                     ]
+                ],
+                "concatenated_haplotypes": [
+                    
                 ]
             }
         ],
-        "timestamp": "2026-05-27T11:00:37.426771853",
+        "timestamp": "2026-07-10T11:24:25.123969983",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.02.0"
+            "nextflow": "26.06.0"
         }
     },
-    "child with two parents, trio-binning mode -stub": {
+    "child with two parents, trio-binning mode, concatenated_haplotypes output -stub": {
         "content": [
             {
                 "0": [
@@ -1528,6 +1670,47 @@
                         "HG004_haplotype_2.assembly_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "2": [
+                    [
+                        {
+                            "id": "HG002",
+                            "n_files": 1,
+                            "relationship": "child",
+                            "children": [
+                                
+                            ],
+                            "family_id": "NIST",
+                            "two_parents": true
+                        },
+                        "HG002:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ],
+                    [
+                        {
+                            "id": "HG003",
+                            "n_files": 1,
+                            "relationship": "father",
+                            "children": [
+                                "HG002"
+                            ],
+                            "family_id": "NIST",
+                            "has_other_parent": true
+                        },
+                        "HG003:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ],
+                    [
+                        {
+                            "id": "HG004",
+                            "n_files": 1,
+                            "relationship": "mother",
+                            "children": [
+                                "HG002"
+                            ],
+                            "family_id": "NIST",
+                            "has_other_parent": true
+                        },
+                        "HG004:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
                 "assembled_haplotypes": [
                     [
                         {
@@ -1699,13 +1882,54 @@
                         },
                         "HG004_haplotype_2.assembly_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
+                ],
+                "concatenated_haplotypes": [
+                    [
+                        {
+                            "id": "HG002",
+                            "n_files": 1,
+                            "relationship": "child",
+                            "children": [
+                                
+                            ],
+                            "family_id": "NIST",
+                            "two_parents": true
+                        },
+                        "HG002:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ],
+                    [
+                        {
+                            "id": "HG003",
+                            "n_files": 1,
+                            "relationship": "father",
+                            "children": [
+                                "HG002"
+                            ],
+                            "family_id": "NIST",
+                            "has_other_parent": true
+                        },
+                        "HG003:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ],
+                    [
+                        {
+                            "id": "HG004",
+                            "n_files": 1,
+                            "relationship": "mother",
+                            "children": [
+                                "HG002"
+                            ],
+                            "family_id": "NIST",
+                            "has_other_parent": true
+                        },
+                        "HG004:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ]
             }
         ],
-        "timestamp": "2026-05-27T11:01:50.626213419",
+        "timestamp": "2026-07-10T11:26:00.388402995",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.02.0"
+            "nextflow": "26.06.0"
         }
     }
 }

--- a/tests/samplesheet.nf.test.snap
+++ b/tests/samplesheet.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "test profile": {
         "content": [
-            232,
+            231,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -115,11 +115,6 @@
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
-                },
-                "FIND_CONCATENATE": {
-                    "coreutils": 9.4,
-                    "find": "4.6.0",
-                    "pigz": 2.8
                 },
                 "GATK4_DENOISEREADCOUNTS": {
                     "gatk4": "4.6.2.0"
@@ -852,7 +847,7 @@
                 
             ]
         ],
-        "timestamp": "2026-07-10T11:29:22.021846856",
+        "timestamp": "2026-07-10T13:25:40.919592338",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.06.0"

--- a/tests/samplesheet.nf.test.snap
+++ b/tests/samplesheet.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "test profile": {
         "content": [
-            231,
+            232,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -115,6 +115,11 @@
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
+                },
+                "FIND_CONCATENATE": {
+                    "coreutils": 9.4,
+                    "find": "4.6.0",
+                    "pigz": 2.8
                 },
                 "GATK4_DENOISEREADCOUNTS": {
                     "gatk4": "4.6.2.0"
@@ -847,10 +852,10 @@
                 
             ]
         ],
-        "timestamp": "2026-06-23T16:47:39.398576638",
+        "timestamp": "2026-07-10T11:29:22.021846856",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.03.4"
+            "nextflow": "26.06.0"
         }
     }
 }

--- a/tests/samplesheet_multisample_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_bam.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "samplesheet_multisample_bam": {
         "content": [
-            400,
+            403,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -115,6 +115,11 @@
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
+                },
+                "FIND_CONCATENATE": {
+                    "coreutils": 9.4,
+                    "find": "4.6.0",
+                    "pigz": 2.8
                 },
                 "GATK4_DENOISEREADCOUNTS": {
                     "gatk4": "4.6.2.0"
@@ -1320,10 +1325,10 @@
                 
             ]
         ],
-        "timestamp": "2026-07-08T10:35:35.405991741",
+        "timestamp": "2026-07-10T11:32:44.12749604",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.03.4"
+            "nextflow": "26.06.0"
         }
     }
 }

--- a/tests/samplesheet_multisample_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_bam.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "samplesheet_multisample_bam": {
         "content": [
-            403,
+            400,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -115,11 +115,6 @@
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
-                },
-                "FIND_CONCATENATE": {
-                    "coreutils": 9.4,
-                    "find": "4.6.0",
-                    "pigz": 2.8
                 },
                 "GATK4_DENOISEREADCOUNTS": {
                     "gatk4": "4.6.2.0"
@@ -1325,7 +1320,7 @@
                 
             ]
         ],
-        "timestamp": "2026-07-10T11:32:44.12749604",
+        "timestamp": "2026-07-10T13:29:02.260916406",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.06.0"

--- a/tests/samplesheet_multisample_ont_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_ont_bam.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "samplesheet_multisample_ont_bam | --preset ONT_R10 --phaser whatshap --alignment_processes 1 --snv_calling_processes 1 --sv_caller sniffles --publish_unannotated_family_svs": {
         "content": [
-            341,
+            344,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -93,6 +93,11 @@
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
+                },
+                "FIND_CONCATENATE": {
+                    "coreutils": 9.4,
+                    "find": "4.6.0",
+                    "pigz": 2.8
                 },
                 "GATK4_DENOISEREADCOUNTS": {
                     "gatk4": "4.6.2.0"
@@ -1226,10 +1231,10 @@
                 
             ]
         ],
-        "timestamp": "2026-06-23T16:57:16.948077305",
+        "timestamp": "2026-07-10T11:37:01.485791832",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.03.4"
+            "nextflow": "26.06.0"
         }
     }
 }

--- a/tests/samplesheet_multisample_ont_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_ont_bam.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "samplesheet_multisample_ont_bam | --preset ONT_R10 --phaser whatshap --alignment_processes 1 --snv_calling_processes 1 --sv_caller sniffles --publish_unannotated_family_svs": {
         "content": [
-            344,
+            341,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -93,11 +93,6 @@
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
-                },
-                "FIND_CONCATENATE": {
-                    "coreutils": 9.4,
-                    "find": "4.6.0",
-                    "pigz": 2.8
                 },
                 "GATK4_DENOISEREADCOUNTS": {
                     "gatk4": "4.6.2.0"
@@ -1231,7 +1226,7 @@
                 
             ]
         ],
-        "timestamp": "2026-07-10T11:37:01.485791832",
+        "timestamp": "2026-07-10T14:28:19.113979164",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.06.0"

--- a/tests/samplesheet_target_regions_null.nf.test.snap
+++ b/tests/samplesheet_target_regions_null.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "test profile | --target_regions null --alignment_output_format cram": {
         "content": [
-            223,
+            222,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -115,11 +115,6 @@
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
-                },
-                "FIND_CONCATENATE": {
-                    "coreutils": 9.4,
-                    "find": "4.6.0",
-                    "pigz": 2.8
                 },
                 "GATK4_DENOISEREADCOUNTS": {
                     "gatk4": "4.6.2.0"
@@ -835,7 +830,7 @@
                 
             ]
         ],
-        "timestamp": "2026-07-10T11:38:54.849595698",
+        "timestamp": "2026-07-10T13:36:50.020637603",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.06.0"

--- a/tests/samplesheet_target_regions_null.nf.test.snap
+++ b/tests/samplesheet_target_regions_null.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "test profile | --target_regions null --alignment_output_format cram": {
         "content": [
-            222,
+            223,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -115,6 +115,11 @@
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
+                },
+                "FIND_CONCATENATE": {
+                    "coreutils": 9.4,
+                    "find": "4.6.0",
+                    "pigz": 2.8
                 },
                 "GATK4_DENOISEREADCOUNTS": {
                     "gatk4": "4.6.2.0"
@@ -830,10 +835,10 @@
                 
             ]
         ],
-        "timestamp": "2026-07-08T10:46:53.503516445",
+        "timestamp": "2026-07-10T11:38:54.849595698",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.03.4"
+            "nextflow": "26.06.0"
         }
     }
 }

--- a/tests/stub_alignment_assembly.nf.test.snap
+++ b/tests/stub_alignment_assembly.nf.test.snap
@@ -106,8 +106,13 @@
     },
     "Test genome assembly without alignment": {
         "content": [
-            17,
+            18,
             {
+                "FIND_CONCATENATE": {
+                    "coreutils": 9.4,
+                    "find": "4.6.0",
+                    "pigz": 2.8
+                },
                 "GFASTATS": {
                     "gfastats": "1.3.11"
                 },
@@ -165,10 +170,10 @@
                 "pipeline_info/nallo_software_mqc_versions.yml"
             ]
         ],
-        "timestamp": "2026-05-27T11:28:36.47024665",
+        "timestamp": "2026-07-10T11:39:45.623618426",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.02.0"
+            "nextflow": "26.06.0"
         }
     },
     "Test alignment without genome assembly": {

--- a/tests/stub_alignment_assembly.nf.test.snap
+++ b/tests/stub_alignment_assembly.nf.test.snap
@@ -106,13 +106,8 @@
     },
     "Test genome assembly without alignment": {
         "content": [
-            18,
+            17,
             {
-                "FIND_CONCATENATE": {
-                    "coreutils": 9.4,
-                    "find": "4.6.0",
-                    "pigz": 2.8
-                },
                 "GFASTATS": {
                     "gfastats": "1.3.11"
                 },
@@ -170,7 +165,7 @@
                 "pipeline_info/nallo_software_mqc_versions.yml"
             ]
         ],
-        "timestamp": "2026-07-10T11:39:45.623618426",
+        "timestamp": "2026-07-10T13:23:04.669912083",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.06.0"

--- a/tests/stub_same_family_and_sample_id.nf.test.snap
+++ b/tests/stub_same_family_and_sample_id.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "Test family id same as sample id": {
         "content": [
-            192,
+            193,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -112,6 +112,11 @@
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
+                },
+                "FIND_CONCATENATE": {
+                    "coreutils": 9.4,
+                    "find": "4.6.0",
+                    "pigz": 2.8
                 },
                 "GATK4_DENOISEREADCOUNTS": {
                     "gatk4": "4.6.2.0"
@@ -511,10 +516,10 @@
                 "visualization_tracks/HG002_Revio/HG002_Revio_pbcpgtools.hap2.bw"
             ]
         ],
-        "timestamp": "2026-07-05T21:56:22.137144",
+        "timestamp": "2026-07-10T11:41:51.966986279",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.4"
+            "nextflow": "26.06.0"
         }
     }
 }

--- a/tests/stub_same_family_and_sample_id.nf.test.snap
+++ b/tests/stub_same_family_and_sample_id.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "Test family id same as sample id": {
         "content": [
-            193,
+            192,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -112,11 +112,6 @@
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
-                },
-                "FIND_CONCATENATE": {
-                    "coreutils": 9.4,
-                    "find": "4.6.0",
-                    "pigz": 2.8
                 },
                 "GATK4_DENOISEREADCOUNTS": {
                     "gatk4": "4.6.2.0"
@@ -516,7 +511,7 @@
                 "visualization_tracks/HG002_Revio/HG002_Revio_pbcpgtools.hap2.bw"
             ]
         ],
-        "timestamp": "2026-07-10T11:41:51.966986279",
+        "timestamp": "2026-07-10T13:39:42.251943161",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.06.0"

--- a/tests/stub_sawfish_joint_call_single_sample.nf.test.snap
+++ b/tests/stub_sawfish_joint_call_single_sample.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "Test sawfish with force_sawfish_joint_call_single_samples true": {
         "content": [
-            59,
+            60,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -44,6 +44,11 @@
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
+                },
+                "FIND_CONCATENATE": {
+                    "coreutils": 9.4,
+                    "find": "4.6.0",
+                    "pigz": 2.8
                 },
                 "GAWK_EXTRACT_REGIONS": {
                     "gawk": "5.3.1"
@@ -210,10 +215,10 @@
                 "visualization_tracks/test/test_maf_sawfish.bw"
             ]
         ],
-        "timestamp": "2026-07-05T21:30:13.736637",
+        "timestamp": "2026-07-10T11:42:18.791893487",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.4"
+            "nextflow": "26.06.0"
         }
     }
 }

--- a/tests/stub_sawfish_joint_call_single_sample.nf.test.snap
+++ b/tests/stub_sawfish_joint_call_single_sample.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "Test sawfish with force_sawfish_joint_call_single_samples true": {
         "content": [
-            60,
+            59,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -44,11 +44,6 @@
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
-                },
-                "FIND_CONCATENATE": {
-                    "coreutils": 9.4,
-                    "find": "4.6.0",
-                    "pigz": 2.8
                 },
                 "GAWK_EXTRACT_REGIONS": {
                     "gawk": "5.3.1"
@@ -215,7 +210,7 @@
                 "visualization_tracks/test/test_maf_sawfish.bw"
             ]
         ],
-        "timestamp": "2026-07-10T11:42:18.791893487",
+        "timestamp": "2026-07-10T13:23:36.309541629",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.06.0"

--- a/tests/stub_sex_check.nf.test.snap
+++ b/tests/stub_sex_check.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "Test skip sex check - unknown sex": {
         "content": [
-            36,
+            35,
             {
                 "BCFTOOLS_MERGE": {
                     "bcftools": 1.22
@@ -17,11 +17,6 @@
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
-                },
-                "FIND_CONCATENATE": {
-                    "coreutils": 9.4,
-                    "find": "4.6.0",
-                    "pigz": 2.8
                 },
                 "GAWK": {
                     "gawk": "5.3.1"
@@ -149,7 +144,7 @@
                 "qc/sambamba_depth/HG002_Revio/HG002_Revio_sambamba_depth.bed"
             ]
         ],
-        "timestamp": "2026-07-10T11:42:41.384303238",
+        "timestamp": "2026-07-10T13:40:33.711602959",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.06.0"

--- a/tests/stub_sex_check.nf.test.snap
+++ b/tests/stub_sex_check.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "Test skip sex check - unknown sex": {
         "content": [
-            35,
+            36,
             {
                 "BCFTOOLS_MERGE": {
                     "bcftools": 1.22
@@ -17,6 +17,11 @@
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
+                },
+                "FIND_CONCATENATE": {
+                    "coreutils": 9.4,
+                    "find": "4.6.0",
+                    "pigz": 2.8
                 },
                 "GAWK": {
                     "gawk": "5.3.1"
@@ -144,10 +149,10 @@
                 "qc/sambamba_depth/HG002_Revio/HG002_Revio_sambamba_depth.bed"
             ]
         ],
-        "timestamp": "2026-05-27T11:31:54.895514708",
+        "timestamp": "2026-07-10T11:42:41.384303238",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.02.0"
+            "nextflow": "26.06.0"
         }
     },
     "Test skip sex check - multisample": {

--- a/workflows/nallo.nf
+++ b/workflows/nallo.nf
@@ -261,7 +261,7 @@ workflow NALLO {
         GENOME_ASSEMBLY(
             ch_genome_assembly_input,
             val_hifiasm_mode == "trio-binning",
-            true,
+            false,
         )
 
         ALIGN_ASSEMBLIES(

--- a/workflows/nallo.nf
+++ b/workflows/nallo.nf
@@ -261,6 +261,7 @@ workflow NALLO {
         GENOME_ASSEMBLY(
             ch_genome_assembly_input,
             val_hifiasm_mode == "trio-binning",
+            true,
         )
 
         ALIGN_ASSEMBLIES(


### PR DESCRIPTION
## Description
This PR closes #1191 

Portello needs to map the reads to the assembly but `HIFIASM` outputs one assembly per haplotype. This PR adds a step to concatenate the assembly into one file. 

### Added

- Added `concatenated_haplotypes` output to `genome_assembly`

### Changed

-

### Fixed

- Fixed typo for entry 1178 in changelog

### Removed

-
