### PR TITLE
Update genmod modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1189](https://github.com/genomic-medicine-sweden/nallo/pull/1189) - Changed to use intro section added in https://github.com/genomic-medicine-sweden/nf-dev-guidelines/pull/39
 - [#1184](https://github.com/genomic-medicine-sweden/nallo/pull/1184) - Update `.nf-core.yml` to remove lint ignore directive for template strings in `assets/nf-dev-guidelines.yaml`.
 - [#1185](https://github.com/genomic-medicine-sweden/nallo/pull/1185) - Rename nf-dev-guidelines config to `contribution-guidelines-config.yaml`.
+- [#1197](https://github.com/genomic-medicine-sweden/nallo/pull/1197) - Updated all genmod modules
 
 ### Removed
 
@@ -139,6 +140,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | hiphase                        | 1.4.0       | 1.6.0       |
 | echtvar/anno                   | 0.2.2       | 0.2.4       |
 | find/concatenate               |             | 4.6.0       |
+| genmod/annotate                | 3.10.2      | 3.12.0      |
+| genmod/compound                | 3.10.2      | 3.12.0      |
+| genmod/models                  | 3.10.2      | 3.12.0      |
+| genmod/score                   | 3.10.2      | 3.12.0      |
 
 > [!NOTE]
 > Version has been updated if both old and new version information is present.

--- a/modules.json
+++ b/modules.json
@@ -186,24 +186,23 @@
                     },
                     "genmod/annotate": {
                         "branch": "master",
-                        "git_sha": "7557033683e4016e7d474a23445f75deae2fb729",
+                        "git_sha": "d9ea9450490d297bc38cfca10bf8c5bd7d84e413",
                         "installed_by": ["modules"]
                     },
                     "genmod/compound": {
                         "branch": "master",
-                        "git_sha": "7557033683e4016e7d474a23445f75deae2fb729",
+                        "git_sha": "d9ea9450490d297bc38cfca10bf8c5bd7d84e413",
                         "installed_by": ["modules"]
                     },
                     "genmod/models": {
                         "branch": "master",
-                        "git_sha": "7557033683e4016e7d474a23445f75deae2fb729",
+                        "git_sha": "d9ea9450490d297bc38cfca10bf8c5bd7d84e413",
                         "installed_by": ["modules"]
                     },
                     "genmod/score": {
                         "branch": "master",
-                        "git_sha": "fed68e7b4b193b36c1abc552586694d43a88f6fb",
-                        "installed_by": ["modules"],
-                        "patch": "modules/nf-core/genmod/score/genmod-score.diff"
+                        "git_sha": "d9ea9450490d297bc38cfca10bf8c5bd7d84e413",
+                        "installed_by": ["modules"]
                     },
                     "gens/preparecovandbaf": {
                         "branch": "master",

--- a/modules/nf-core/genmod/annotate/environment.yml
+++ b/modules/nf-core/genmod/annotate/environment.yml
@@ -4,5 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::genmod=3.10.2
+  - bioconda::genmod=3.12.0
   - conda-forge::python=3.11.14

--- a/modules/nf-core/genmod/annotate/main.nf
+++ b/modules/nf-core/genmod/annotate/main.nf
@@ -3,9 +3,9 @@ process GENMOD_ANNOTATE {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/31/31b331bee43c7ff070bdde5460a4102ba31c3bfb0ee0d70197001ff011036555/data' :
-        'community.wave.seqera.io/library/genmod_python:31b2fba4d3b7ba6f' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ac/acf051b79e515c6fb504092ca3bae45030c956f4e3f0488e62dab3ad16976146/data' :
+        'community.wave.seqera.io/library/genmod:3.12.0--9b9048c2e842d266' }"
 
     input:
     tuple val(meta), path(input_vcf)

--- a/modules/nf-core/genmod/annotate/tests/main.nf.test.snap
+++ b/modules/nf-core/genmod/annotate/tests/main.nf.test.snap
@@ -8,16 +8,16 @@
                     [
                         "GENMOD_ANNOTATE",
                         "genmod",
-                        "3.10.2"
+                        "3.12.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-07-14T11:25:02.90805062",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-12-22T14:45:39.879885252"
+            "nf-test": "0.9.5",
+            "nextflow": "26.06.0"
+        }
     },
     "genmod_annotate - stub": {
         "content": [
@@ -35,7 +35,7 @@
                     [
                         "GENMOD_ANNOTATE",
                         "genmod",
-                        "3.10.2"
+                        "3.12.0"
                     ]
                 ],
                 "vcf": [
@@ -51,15 +51,15 @@
                     [
                         "GENMOD_ANNOTATE",
                         "genmod",
-                        "3.10.2"
+                        "3.12.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-07-14T11:25:06.420686626",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-12-22T14:14:43.571171183"
+            "nf-test": "0.9.5",
+            "nextflow": "26.06.0"
+        }
     }
 }

--- a/modules/nf-core/genmod/compound/environment.yml
+++ b/modules/nf-core/genmod/compound/environment.yml
@@ -4,5 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::genmod=3.10.2
+  - bioconda::genmod=3.12.0
   - conda-forge::python=3.11.14

--- a/modules/nf-core/genmod/compound/main.nf
+++ b/modules/nf-core/genmod/compound/main.nf
@@ -3,10 +3,9 @@ process GENMOD_COMPOUND {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/31/31b331bee43c7ff070bdde5460a4102ba31c3bfb0ee0d70197001ff011036555/data' :
-        'community.wave.seqera.io/library/genmod_python:31b2fba4d3b7ba6f' }"
-
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ac/acf051b79e515c6fb504092ca3bae45030c956f4e3f0488e62dab3ad16976146/data' :
+        'community.wave.seqera.io/library/genmod:3.12.0--9b9048c2e842d266' }"
     input:
     tuple val(meta), path(input_vcf)
 

--- a/modules/nf-core/genmod/compound/tests/main.nf.test.snap
+++ b/modules/nf-core/genmod/compound/tests/main.nf.test.snap
@@ -7,16 +7,16 @@
                     [
                         "GENMOD_COMPOUND",
                         "genmod",
-                        "3.10.2"
+                        "3.12.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-07-14T11:25:51.518921533",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-12-22T14:47:53.481557902"
+            "nf-test": "0.9.5",
+            "nextflow": "26.06.0"
+        }
     },
     "genmod_compound - stub": {
         "content": [
@@ -34,7 +34,7 @@
                     [
                         "GENMOD_COMPOUND",
                         "genmod",
-                        "3.10.2"
+                        "3.12.0"
                     ]
                 ],
                 "vcf": [
@@ -50,15 +50,15 @@
                     [
                         "GENMOD_COMPOUND",
                         "genmod",
-                        "3.10.2"
+                        "3.12.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-07-14T11:25:54.970912595",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-12-22T14:14:51.229110934"
+            "nf-test": "0.9.5",
+            "nextflow": "26.06.0"
+        }
     }
 }

--- a/modules/nf-core/genmod/models/environment.yml
+++ b/modules/nf-core/genmod/models/environment.yml
@@ -4,5 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::genmod=3.10.2
+  - bioconda::genmod=3.12.0
   - conda-forge::python=3.11.14

--- a/modules/nf-core/genmod/models/main.nf
+++ b/modules/nf-core/genmod/models/main.nf
@@ -3,9 +3,9 @@ process GENMOD_MODELS {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/31/31b331bee43c7ff070bdde5460a4102ba31c3bfb0ee0d70197001ff011036555/data' :
-        'community.wave.seqera.io/library/genmod_python:31b2fba4d3b7ba6f' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ac/acf051b79e515c6fb504092ca3bae45030c956f4e3f0488e62dab3ad16976146/data' :
+        'community.wave.seqera.io/library/genmod:3.12.0--9b9048c2e842d266' }"
 
     input:
     tuple val(meta), path(input_vcf), path (fam)

--- a/modules/nf-core/genmod/models/tests/main.nf.test
+++ b/modules/nf-core/genmod/models/tests/main.nf.test
@@ -8,7 +8,7 @@ nextflow_process {
     tag "genmod"
     tag "genmod/models"
 
-    test("genmod_models") {
+    test("genmod_models without reduced_penetrance") {
 
         when {
             process {
@@ -35,7 +35,34 @@ nextflow_process {
 
     }
 
-    test("genmod_models - stub") {
+    test("genmod_models with reduced_penetrance") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/vcf/test_annotate.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/vcf/ped/justhusky.ped', checkIfExists: true)
+                ]
+                input[1] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/genmod/genmod_reduced_penetrance.tsv', checkIfExists: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.summary,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                ).match() }
+            )
+        }
+
+    }
+
+    test("genmod_models without reduced_penetrance - stub") {
 
         options "-stub"
 

--- a/modules/nf-core/genmod/models/tests/main.nf.test.snap
+++ b/modules/nf-core/genmod/models/tests/main.nf.test.snap
@@ -1,5 +1,43 @@
 {
-    "genmod_models - stub": {
+    "genmod_models without reduced_penetrance": {
+        "content": [
+            "VcfFile [chromosomes=[1], sampleCount=3, variantCount=57, phased=false, phasedAutodetect=false]",
+            {
+                "versions_genmod": [
+                    [
+                        "GENMOD_MODELS",
+                        "genmod",
+                        "3.12.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-14T11:25:58.886140245",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.06.0"
+        }
+    },
+    "genmod_models with reduced_penetrance": {
+        "content": [
+            "VcfFile [chromosomes=[1], sampleCount=3, variantCount=57, phased=false, phasedAutodetect=false]",
+            {
+                "versions_genmod": [
+                    [
+                        "GENMOD_MODELS",
+                        "genmod",
+                        "3.12.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-14T11:26:02.612162213",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.06.0"
+        }
+    },
+    "genmod_models without reduced_penetrance - stub": {
         "content": [
             {
                 "0": [
@@ -15,7 +53,7 @@
                     [
                         "GENMOD_MODELS",
                         "genmod",
-                        "3.10.2"
+                        "3.12.0"
                     ]
                 ],
                 "vcf": [
@@ -31,34 +69,15 @@
                     [
                         "GENMOD_MODELS",
                         "genmod",
-                        "3.10.2"
+                        "3.12.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-07-14T11:26:06.138808373",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-12-22T14:14:58.376387801"
-    },
-    "genmod_models": {
-        "content": [
-            "VcfFile [chromosomes=[1], sampleCount=3, variantCount=57, phased=false, phasedAutodetect=false]",
-            {
-                "versions_genmod": [
-                    [
-                        "GENMOD_MODELS",
-                        "genmod",
-                        "3.10.2"
-                    ]
-                ]
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-12-22T14:47:59.960270364"
+            "nf-test": "0.9.5",
+            "nextflow": "26.06.0"
+        }
     }
 }

--- a/modules/nf-core/genmod/score/environment.yml
+++ b/modules/nf-core/genmod/score/environment.yml
@@ -4,5 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::genmod=3.10.2
+  - bioconda::genmod=3.12.0
   - conda-forge::python=3.11.14

--- a/modules/nf-core/genmod/score/main.nf
+++ b/modules/nf-core/genmod/score/main.nf
@@ -3,9 +3,9 @@ process GENMOD_SCORE {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/31/31b331bee43c7ff070bdde5460a4102ba31c3bfb0ee0d70197001ff011036555/data' :
-        'community.wave.seqera.io/library/genmod_python:31b2fba4d3b7ba6f' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ac/acf051b79e515c6fb504092ca3bae45030c956f4e3f0488e62dab3ad16976146/data' :
+        'community.wave.seqera.io/library/genmod:3.12.0--9b9048c2e842d266' }"
 
     input:
     tuple val(meta), path(input_vcf), path (fam), path (score_config)

--- a/modules/nf-core/genmod/score/tests/main.nf.test.snap
+++ b/modules/nf-core/genmod/score/tests/main.nf.test.snap
@@ -8,16 +8,16 @@
                     [
                         "GENMOD_SCORE",
                         "genmod",
-                        "3.10.2"
+                        "3.12.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-07-14T11:26:09.94912507",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-12-22T14:46:03.729403607"
+            "nf-test": "0.9.5",
+            "nextflow": "26.06.0"
+        }
     },
     "genmod_score - stub": {
         "content": [
@@ -35,7 +35,7 @@
                     [
                         "GENMOD_SCORE",
                         "genmod",
-                        "3.10.2"
+                        "3.12.0"
                     ]
                 ],
                 "vcf": [
@@ -51,15 +51,15 @@
                     [
                         "GENMOD_SCORE",
                         "genmod",
-                        "3.10.2"
+                        "3.12.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-07-14T11:26:13.501442003",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-12-22T14:08:59.88453697"
+            "nf-test": "0.9.5",
+            "nextflow": "26.06.0"
+        }
     }
 }

--- a/tests/samplesheet.nf.test.snap
+++ b/tests/samplesheet.nf.test.snap
@@ -126,16 +126,16 @@
                     "gawk": "5.3.1"
                 },
                 "GENMOD_ANNOTATE": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_COMPOUND": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_MODELS": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_SCORE": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GFASTATS": {
                     "gfastats": "1.3.11"
@@ -847,7 +847,7 @@
                 
             ]
         ],
-        "timestamp": "2026-07-10T15:32:31.916259113",
+        "timestamp": "2026-07-14T13:15:06.440108625",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.06.0"

--- a/tests/samplesheet_multisample_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_bam.nf.test.snap
@@ -126,16 +126,16 @@
                     "gawk": "5.3.1"
                 },
                 "GENMOD_ANNOTATE": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_COMPOUND": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_MODELS": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_SCORE": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GFASTATS": {
                     "gfastats": "1.3.11"
@@ -1320,7 +1320,7 @@
                 
             ]
         ],
-        "timestamp": "2026-07-10T15:35:59.172016652",
+        "timestamp": "2026-07-14T13:22:07.894634776",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.06.0"

--- a/tests/samplesheet_multisample_ont_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_ont_bam.nf.test.snap
@@ -101,16 +101,16 @@
                     "gawk": "5.3.1"
                 },
                 "GENMOD_ANNOTATE": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_COMPOUND": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_MODELS": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_SCORE": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GFASTATS": {
                     "gfastats": "1.3.11"
@@ -1226,7 +1226,7 @@
                 
             ]
         ],
-        "timestamp": "2026-07-10T15:40:11.2857543",
+        "timestamp": "2026-07-14T13:26:28.597990933",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.06.0"

--- a/tests/samplesheet_target_regions_null.nf.test.snap
+++ b/tests/samplesheet_target_regions_null.nf.test.snap
@@ -126,16 +126,16 @@
                     "gawk": "5.3.1"
                 },
                 "GENMOD_ANNOTATE": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_COMPOUND": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_MODELS": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_SCORE": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GFASTATS": {
                     "gfastats": "1.3.11"
@@ -830,7 +830,7 @@
                 
             ]
         ],
-        "timestamp": "2026-07-10T15:42:04.785804954",
+        "timestamp": "2026-07-14T13:28:23.182109195",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.06.0"

--- a/tests/stub_same_family_and_sample_id.nf.test.snap
+++ b/tests/stub_same_family_and_sample_id.nf.test.snap
@@ -123,16 +123,16 @@
                     "gawk": "5.3.1"
                 },
                 "GENMOD_ANNOTATE": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_COMPOUND": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_MODELS": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GENMOD_SCORE": {
-                    "genmod": "3.10.2"
+                    "genmod": "3.12.0"
                 },
                 "GFASTATS": {
                     "gfastats": "1.3.11"
@@ -511,7 +511,7 @@
                 "visualization_tracks/HG002_Revio/HG002_Revio_pbcpgtools.hap2.bw"
             ]
         ],
-        "timestamp": "2026-07-10T15:45:39.544649458",
+        "timestamp": "2026-07-14T13:31:59.33550571",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.06.0"


### PR DESCRIPTION
## Description

New version of genmod fixes #839 and #921 

### Added

-

### Changed

- Updated all genmod modules to v.3.12.0 (annotate, compound, models, score)

### Fixed

- 

### Removed

- Removed patch for `genmod/score` in `modules.json` 
