### PR TITLE
Default ONT-caller should not be mitorsaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1197](https://github.com/genomic-medicine-sweden/nallo/pull/1197) - Updated all genmod modules
 - [#1196](https://github.com/genomic-medicine-sweden/nallo/pull/1196) - Updated SVDB modules
 - [#1206](https://github.com/genomic-medicine-sweden/nallo/pull/1206) - Changed default glnexus config from `DeepVariant_unfiltered` to a custom config in `assets/` due to unfixed [bug](https://github.com/dnanexus-rnd/GLnexus/issues/286)?
+- [#1218](https://github.com/genomic-medicine-sweden/nallo/pull/1218) - Changed default mitochondrial caller for the `ONT_R10` preset to `deepvariant`
 
 ### Removed
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -125,7 +125,7 @@ params {
     hifiasm_mode                               = 'trio-binning'
     snv_caller                                 = 'deepvariant'
     str_caller                                 = params.preset == 'ONT_R10' ? 'strdust' : 'trgt'
-    mitochondrial_caller                       = 'mitorsaw'
+    mitochondrial_caller                       = params.preset == 'ONT_R10' ? 'deepvariant' : 'mitorsaw'
     mitorsaw_minimum_maf                       = 0.1
     mitorsaw_minimum_read_count                = 3
     mitochondrial_sv_min_size                  = 50

--- a/tests/samplesheet_multisample_ont_bam.nf.test
+++ b/tests/samplesheet_multisample_ont_bam.nf.test
@@ -13,7 +13,6 @@ nextflow_pipeline {
                 input                          = "$projectDir/assets/samplesheet_multisample_ont_bam.csv"
                 outdir                         = "$outputDir"
                 preset                         = 'ONT_R10'
-                mitochondrial_caller           = 'deepvariant'
                 alignment_processes            = 1
                 hifiasm_mode                   = 'hifi-only'
                 snv_calling_processes          = 1

--- a/tests/stub_ont_r10_methylation_annotation.nf.test.snap
+++ b/tests/stub_ont_r10_methylation_annotation.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "ONT_R10 preset with default methylation annotation settings": {
         "content": [
-            145,
+            126,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -21,16 +21,10 @@
                 "BCFTOOLS_NORM_SINGLESAMPLE": {
                     "bcftools": 1.22
                 },
-                "BCFTOOLS_SORT": {
-                    "bcftools": 1.22
-                },
                 "BCFTOOLS_STATS": {
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW": {
-                    "bcftools": 1.22
-                },
-                "BCFTOOLS_VIEW_MITO": {
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_PHASING": {
@@ -77,9 +71,6 @@
                 },
                 "MINIMAP2_INDEX": {
                     "minimap2": "2.29-r1283"
-                },
-                "MITORSAW_HAPLOTYPE": {
-                    "mitorsaw": "0.2.9-0dc8e58"
                 },
                 "MODKIT_PILEUP": {
                     "modkit": "0.6.1"
@@ -141,7 +132,7 @@
                 }
             }
         ],
-        "timestamp": "2026-07-14T13:53:43.549060825",
+        "timestamp": "2026-07-27T10:58:47.444208625",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"


### PR DESCRIPTION
## Description

Since mitorsaw is for PacBio data, the default mitochondrial caller for the ONT-preset should not be mitorsaw.


### Changed

- Changed default ONT mito-caller to deepvariant
