### PR TITLE
CI: retry nf-test once on transient network/disk failures

### DIFF
--- a/.github/actions/nf-test/action.yml
+++ b/.github/actions/nf-test/action.yml
@@ -64,7 +64,7 @@ runs:
 
         set -o pipefail
         if ! run_nf_test 2>&1 | tee nf-test.log; then
-          if grep -qE "Connection reset|Connection timed out|no space left on device|Can't stage file.*https://|file does not exist.*https://" nf-test.log; then
+          if grep -iqE "connection reset|Connection timed out|no space left on device|Can't stage file.*https://|file does not exist.*https://|Failed to pull singularity image" nf-test.log; then
             echo "::warning::Transient network/disk failure detected — retrying once"
             run_nf_test
           else

--- a/.github/actions/nf-test/action.yml
+++ b/.github/actions/nf-test/action.yml
@@ -64,7 +64,7 @@ runs:
 
         set -o pipefail
         if ! run_nf_test 2>&1 | tee nf-test.log; then
-          if grep -iqE "connection reset|Connection timed out|no space left on device|Can't stage file.*https://|file does not exist.*https://|Failed to pull singularity image" nf-test.log; then
+          if grep -iqE "connection reset|Connection timed out|no space left on device|Can't stage file.*https://|file does not exist.*https://|Failed to pull singularity image|unexpected HTTP status: 5" nf-test.log; then
             echo "::warning::Transient network/disk failure detected — retrying once"
             run_nf_test
           else

--- a/.github/actions/nf-test/action.yml
+++ b/.github/actions/nf-test/action.yml
@@ -51,17 +51,26 @@ runs:
       env:
         NFT_WORKDIR: ${{ env.NFT_WORKDIR }}
       run: |
-        nf-test test \
-          --profile=+${{ inputs.profile }} \
-          $(if [ -n "${{ inputs.tags }}" ]; then echo "--tag ${{ inputs.tags }}"; fi) \
-          --ci \
-          --changed-since HEAD^ \
-          --verbose \
-          --tap=test.tap \
-          --shard ${{ inputs.shard }}/${{ inputs.total_shards }}
+        run_nf_test() {
+          nf-test test \
+            --profile=+${{ inputs.profile }} \
+            $(if [ -n "${{ inputs.tags }}" ]; then echo "--tag ${{ inputs.tags }}"; fi) \
+            --ci \
+            --changed-since HEAD^ \
+            --verbose \
+            --tap=test.tap \
+            --shard ${{ inputs.shard }}/${{ inputs.total_shards }}
+        }
 
-          # Save the absolute path of the test.tap file to the output
-          echo "tap_file_path=$(realpath test.tap)" >> $GITHUB_OUTPUT
+        set -o pipefail
+        if ! run_nf_test 2>&1 | tee nf-test.log; then
+          if grep -qE "Connection reset|Connection timed out|no space left on device|Can't stage file.*https://|file does not exist.*https://" nf-test.log; then
+            echo "::warning::Transient network/disk failure detected — retrying once"
+            run_nf_test
+          else
+            exit 1
+          fi
+        fi
 
     - name: Generate test summary
       if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1196](https://github.com/genomic-medicine-sweden/nallo/pull/1196) - Updated SVDB modules
 - [#1206](https://github.com/genomic-medicine-sweden/nallo/pull/1206) - Changed default glnexus config from `DeepVariant_unfiltered` to a custom config in `assets/` due to unfixed [bug](https://github.com/dnanexus-rnd/GLnexus/issues/286)?
 - [#1218](https://github.com/genomic-medicine-sweden/nallo/pull/1218) - Changed default mitochondrial caller for the `ONT_R10` preset to `deepvariant`
+- [#1219](https://github.com/genomic-medicine-sweden/nallo/pull/1219) - Changed nf-test CI action to retry once on transient network/disk failures
 
 ### Removed
 


### PR DESCRIPTION
## Summary

Transient infrastructure failures occasionally cause CI jobs to fail spuriously, requiring a manual re-run. This adds a single automatic retry when the failure is clearly transient, without masking genuine test failures.

## What changes

The `Run nf-test` step in `.github/actions/nf-test/action.yml` now:
1. Captures nf-test stdout+stderr to `nf-test.log` via `tee` (with `set -o pipefail` so the exit code comes from nf-test, not `tee`)
2. On failure, case-insensitively greps the log for known transient patterns — if found, emits a `::warning::` annotation and retries once
3. On failure without a transient pattern, exits immediately — genuine snapshot diffs, config errors, etc. are never retried

## Transient patterns matched

All patterns confirmed in this repo's CI failure history:

| Pattern | Observed as |
|---|---|
| `connection reset` (case-insensitive) | `Can't stage file https://... -- reason: Connection reset`; `curl: (35) Recv failure: Connection reset by peer`; Docker/singularity `read: connection reset by peer` |
| `Can't stage file.*https://` | nf-test staging failure downloading test BAM / TRF bed from GitHub raw (run [30029889883](https://github.com/genomic-medicine-sweden/nallo/actions/runs/30029889883)) |
| `no space left on device` | disk exhaustion from Docker image pulls on NXF 26.07.0-edge runners |
| `file does not exist.*https://` | NXF 26.04.4 URL validation on remote test assets — safe to retry: clears if transient, fails again if genuinely missing |
| `Failed to pull singularity image` | singularity pull timeout / connection reset on `singularity` profile jobs |
| `unexpected HTTP status: 5` | HTTP 5xx from container registries (e.g. `504 Gateway Time-out` from quay.io pulling `biocontainers/yak`) |
| `Connection timed out` | TCP timeout variant — not seen verbatim in this repo but included defensively |

## Note

The retry triggers on *presence* of a network/disk error, not *absence* of a snapshot diff. A network failure mid-run can produce partial output that itself causes a snapshot mismatch, so excluding "Different Snapshot" would be the wrong signal.