### PR TITLE
Move VCFEXPRESS to MERGE_SVS subworkflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1218](https://github.com/genomic-medicine-sweden/nallo/pull/1218) - Changed default mitochondrial caller for the `ONT_R10` preset to `deepvariant`
 - [#1219](https://github.com/genomic-medicine-sweden/nallo/pull/1219) - Changed nf-test CI action to retry once on transient network/disk failures
 - [#1141](https://github.com/genomic-medicine-sweden/nallo/pull/1141) - Moved merging of vcfs out of `CALL_SVS` in new `MERGE_SVS` subworkflow
+- [#1229](https://github.com/genomic-medicine-sweden/nallo/pull/1229) - Moved `VCFEXPRESS` (FOUND_IN tagging) from `CALL_SVS` to `MERGE_SVS`, running after `SVDB_MERGE_BY_CALLER`
 
 ### Removed
 

--- a/conf/modules/call_svs.config
+++ b/conf/modules/call_svs.config
@@ -24,16 +24,6 @@ process {
         ext.args   = { meta.sv_caller == 'sniffles' ? '--caller sniffles1' : '' }
     }
 
-    withName: '.*:CALL_SVS:VCFEXPRESS' {
-        ext.prefix = { "${meta.id}_${meta.sv_caller}_found_in" }
-        ext.suffix = { "vcf.gz" }
-        ext.args   = { "-s \'FOUND_IN=return \"${meta.sv_caller}\"\' -e \"return true\"" }
-    }
-
-    withName: '.*:CALL_SVS:TABIX_VCFEXPRESS' {
-        ext.prefix = { "${meta.id}_${meta.sv_caller}_found_in" }
-    }
-
     withName: '.*:CALL_SVS:BCFTOOLS_VIEW' {
         ext.prefix = { "${meta.id}_${meta.sv_caller}_filtered" }
         ext.args   = ['--output-type z', '--write-index=tbi'].join(' ')

--- a/conf/modules/merge_svs.config
+++ b/conf/modules/merge_svs.config
@@ -18,6 +18,12 @@ process {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     */
 
+    withName: '.*:MERGE_SVS:VCFEXPRESS' {
+        ext.prefix = { "${meta.id}_${meta.sv_caller}_found_in" }
+        ext.suffix = { "vcf.gz" }
+        ext.args   = { "-s \'FOUND_IN=return \"${meta.sv_caller}\"\' -e \"return true\"" }
+    }
+
     withName: '.*:MERGE_SVS:SVDB_MERGE_BY_CALLER' {
         tag        = { "${meta.id}_${meta.sv_caller}" }
         ext.prefix = { "${meta.id}_${meta.sv_caller}_svs" }

--- a/conf/modules/merge_svs.config
+++ b/conf/modules/merge_svs.config
@@ -18,12 +18,6 @@ process {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     */
 
-    withName: '.*:MERGE_SVS:VCFEXPRESS' {
-        ext.prefix = { "${meta.id}_${meta.sv_caller}_found_in" }
-        ext.suffix = { "vcf.gz" }
-        ext.args   = { "-s \'FOUND_IN=return \"${meta.sv_caller}\"\' -e \"return true\"" }
-    }
-
     withName: '.*:MERGE_SVS:SVDB_MERGE_BY_CALLER' {
         tag        = { "${meta.id}_${meta.sv_caller}" }
         ext.prefix = { "${meta.id}_${meta.sv_caller}_svs" }
@@ -31,6 +25,12 @@ process {
             [meta.sv_caller == 'hificnv' ? '--bnd_distance 10000' : '--bnd_distance 1000', meta.sv_caller == 'sawfish' && !params.force_sawfish_joint_call_single_samples ? '--no_intra' : '', '--overlap .5'].join(' ')
         }
         ext.args2  = ['--output-type z', '--write-index=tbi'].join(' ')
+    }
+
+    withName: '.*:MERGE_SVS:VCFEXPRESS' {
+        ext.prefix = { "${meta.id}_${meta.sv_caller}_found_in" }
+        ext.suffix = { "vcf.gz" }
+        ext.args   = { "-s \'FOUND_IN=return \"${meta.sv_caller}\"\' -e \"return true\"" }
     }
 
     withName: '.*:MERGE_SVS:SVDB_MERGE_BY_FAMILY' {

--- a/subworkflows/local/call_svs/main.nf
+++ b/subworkflows/local/call_svs/main.nf
@@ -9,9 +9,7 @@ include { SAWFISH_JOINTCALL                 } from '../../../modules/nf-core/saw
 include { SEVERUS                           } from '../../../modules/nf-core/severus/main'
 include { SNIFFLES                          } from '../../../modules/nf-core/sniffles/main'
 include { TABIX_TABIX as TABIX_HIFICNV      } from '../../../modules/nf-core/tabix/tabix/main'
-include { TABIX_TABIX as TABIX_VCFEXPRESS   } from '../../../modules/nf-core/tabix/tabix/main'
 include { TABIX_BGZIPTABIX as TABIX_SEVERUS } from '../../../modules/nf-core/tabix/bgziptabix/main'
-include { VCFEXPRESS                        } from '../../../modules/nf-core/vcfexpress/main'
 include { VEP_PREP_SV                       } from '../../../modules/local/vep_prep_sv/main'
 
 workflow CALL_SVS {
@@ -29,7 +27,6 @@ workflow CALL_SVS {
     force_sawfish_joint_call_single_samples //    bool: Force joint-calling with Sawfish even for single samples
     create_hificnv_maf_track //    bool: Should we create a MAF track for HiFiCNV/Sawfish calls?
     create_sawfish_maf_track //    bool: Should we create a MAF track for HiFiCNV/Sawfish calls?
-    ch_vcfexpress_prelude // path: lua file
 
     main:
     ch_sv_calls = channel.empty()
@@ -217,26 +214,18 @@ workflow CALL_SVS {
         ch_sv_calls_filtered = ch_sv_calls
     }
 
-    ch_vcfexpress_input = ch_sv_calls_filtered.multiMap { meta, vcf, _tbi ->
-        vcf: [meta, vcf]
-        sv_caller: meta.sv_caller
-    }
-
-    VCFEXPRESS(
-        ch_vcfexpress_input.vcf,
-        ch_vcfexpress_prelude,
-    )
-
     // If Severus or Sniffles was used, we need to reheader the VCF
     // Since Sniffles hardcodes the sample name as SAMPLE, and Severus bases it on the file name.
     // HiFiCNV doesn't have this issue, so we filter it out here, and add it back later.
 
     // Starting with getting the sample name from the VCF
-    ch_found_in_tagged_vcf = VCFEXPRESS.out.vcf.branch { meta, _vcf ->
-        def callers_needing_reheader = ['severus', 'sniffles']
-        to_reheader: callers_needing_reheader.contains(meta.sv_caller)
-        no_reheader: !callers_needing_reheader.contains(meta.sv_caller)
-    }
+    ch_found_in_tagged_vcf = ch_sv_calls_filtered
+        .map { meta, vcf, _tbi -> [meta, vcf] }
+        .branch { meta, _vcf ->
+            def callers_needing_reheader = ['severus', 'sniffles']
+            to_reheader: callers_needing_reheader.contains(meta.sv_caller)
+            no_reheader: !callers_needing_reheader.contains(meta.sv_caller)
+        }
 
     BCFTOOLS_QUERY(
         ch_found_in_tagged_vcf.to_reheader.map { meta, vcf -> [meta, vcf, []] },

--- a/subworkflows/local/call_svs/tests/main.nf.test
+++ b/subworkflows/local/call_svs/tests/main.nf.test
@@ -89,7 +89,6 @@ nextflow_workflow {
                 input[10] = false
                 input[11] = true
                 input[12] = true
-                input[13] = file('../../../assets/vcf_express_found_in_prelude.lua')
                 """
             }
         }
@@ -152,7 +151,6 @@ nextflow_workflow {
                 input[10] = false
                 input[11] = true
                 input[12] = true
-                input[13] = file('../../../assets/vcf_express_found_in_prelude.lua')
                 """
             }
         }
@@ -216,7 +214,6 @@ nextflow_workflow {
                 input[10] = true
                 input[11] = true
                 input[12] = true
-                input[13] = file('../../../assets/vcf_express_found_in_prelude.lua')
                 """
             }
         }
@@ -274,7 +271,6 @@ nextflow_workflow {
                 input[10] = false
                 input[11] = true
                 input[12] = true
-                input[13] = file('../../../assets/vcf_express_found_in_prelude.lua')
                 """
             }
         }
@@ -332,7 +328,6 @@ nextflow_workflow {
                 input[10] = false
                 input[11] = false
                 input[12] = false
-                input[13] = file('../../../assets/vcf_express_found_in_prelude.lua')
                 """
             }
         }
@@ -394,7 +389,6 @@ nextflow_workflow {
                 input[10] = false
                 input[11] = true
                 input[12] = true
-                input[13] = file('../../../assets/vcf_express_found_in_prelude.lua')
                 """
             }
         }
@@ -455,7 +449,6 @@ nextflow_workflow {
                 input[10] = true
                 input[11] = true
                 input[12] = true
-                input[13] = file('../../../assets/vcf_express_found_in_prelude.lua')
                 """
             }
         }
@@ -514,7 +507,6 @@ nextflow_workflow {
                 input[10] = false
                 input[11] = true
                 input[12] = true
-                input[13] = file('../../../assets/vcf_express_found_in_prelude.lua')
                 """
             }
         }
@@ -577,7 +569,6 @@ nextflow_workflow {
                 input[10] = false
                 input[11] = true
                 input[12] = true
-                input[13] = file('../../../assets/vcf_express_found_in_prelude.lua')
                 """
             }
         }

--- a/subworkflows/local/call_svs/tests/main.nf.test.snap
+++ b/subworkflows/local/call_svs/tests/main.nf.test.snap
@@ -10,10 +10,10 @@
                     },
                     [
                         [
-                            "test_1_hificnv_found_in.vcf.gz"
+                            "test_1_hificnv_filtered.vcf.gz"
                         ],
                         [
-                            "test_2_hificnv_found_in.vcf.gz"
+                            "test_2_hificnv_filtered.vcf.gz"
                         ]
                     ]
                 ],
@@ -25,10 +25,10 @@
                     },
                     [
                         [
-                            "test_1_sawfish_found_in.vcf.gz"
+                            "test_1_sawfish_filtered.vcf.gz"
                         ],
                         [
-                            "test_2_sawfish_found_in.vcf.gz"
+                            "test_2_sawfish_filtered.vcf.gz"
                         ]
                     ]
                 ],
@@ -42,12 +42,12 @@
                         [
                             "test_1_reheader.vcf.gz",
                             "VcfFile [chromosomes=[chr16], sampleCount=1, variantCount=1, phased=false, phasedAutodetect=false]",
-                            "ae1e654608d3aa822ba69b57ce31a861"
+                            "62cf182304490e1ecd958247dc8e8727"
                         ],
                         [
                             "test_2_reheader.vcf.gz",
                             "VcfFile [chromosomes=[chr16], sampleCount=1, variantCount=1, phased=false, phasedAutodetect=false]",
-                            "ea83940547c0bc15eb6b4c9a59159406"
+                            "582b249ead6e03350420af97130b92be"
                         ]
                     ]
                 ],
@@ -61,7 +61,7 @@
                         [
                             "test_1_reheader.vcf.gz",
                             "VcfFile [chromosomes=[chr16], sampleCount=1, variantCount=1, phased=false, phasedAutodetect=false]",
-                            "1b214fb9e1e9bcc3d7719580c2a6bbc6"
+                            "b5b3aad900660c9b5f9ea6d412e631ff"
                         ],
                         [
                             "test_2_reheader.vcf.gz",
@@ -72,10 +72,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-08-06T13:28:28.118590273",
+        "timestamp": "2026-08-13T09:16:45.784089999",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.07.0"
+            "nextflow": "26.04.6"
         }
     },
     "1 sample, 1 family - sniffles": {
@@ -91,16 +91,16 @@
                         [
                             "test_reheader.vcf.gz",
                             "VcfFile [chromosomes=[chrX, chr16, chr17, chrM, chr20], sampleCount=1, variantCount=21, phased=false, phasedAutodetect=false]",
-                            "4ef4a55d60b44c349a56e1516ad2542a"
+                            "9782117a680da92761a99064a57bbd82"
                         ]
                     ]
                 ]
             ]
         ],
-        "timestamp": "2026-08-06T13:24:00.599335125",
+        "timestamp": "2026-08-13T09:10:40.879992527",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.07.0"
+            "nextflow": "26.04.6"
         }
     },
     "1 sample, 1 family - sawfish": {
@@ -114,16 +114,16 @@
                     },
                     [
                         [
-                            "family_sawfish_found_in.vcf.gz"
+                            "family_sawfish_jointcall_genotyped.sv.vcf.gz"
                         ]
                     ]
                 ]
             ]
         ],
-        "timestamp": "2026-08-06T13:24:41.564844587",
+        "timestamp": "2026-08-13T09:11:38.051364511",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.07.0"
+            "nextflow": "26.04.6"
         }
     },
     "2 samples, 1 family - hificnv,sawfish with trf bed, no MAF track": {
@@ -137,10 +137,10 @@
                     },
                     [
                         [
-                            "test_1_hificnv_found_in.vcf.gz"
+                            "test_1_hificnv.test_1.vcf.gz"
                         ],
                         [
-                            "test_2_hificnv_found_in.vcf.gz"
+                            "test_2_hificnv.test_2.vcf.gz"
                         ]
                     ]
                 ],
@@ -152,16 +152,16 @@
                     },
                     [
                         [
-                            "family_sawfish_found_in.vcf.gz"
+                            "family_sawfish_jointcall_genotyped.sv.vcf.gz"
                         ]
                     ]
                 ]
             ]
         ],
-        "timestamp": "2026-08-06T13:26:50.58963561",
+        "timestamp": "2026-08-13T09:14:54.211268058",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.07.0"
+            "nextflow": "26.04.6"
         }
     },
     "2 samples, 1 family - sniffes,severus,hificnv,sawfish with trf bed": {
@@ -175,10 +175,10 @@
                     },
                     [
                         [
-                            "test_1_hificnv_found_in.vcf.gz"
+                            "test_1_hificnv.test_1.vcf.gz"
                         ],
                         [
-                            "test_2_hificnv_found_in.vcf.gz"
+                            "test_2_hificnv.test_2.vcf.gz"
                         ]
                     ]
                 ],
@@ -190,7 +190,7 @@
                     },
                     [
                         [
-                            "family_sawfish_found_in.vcf.gz"
+                            "family_sawfish_jointcall_genotyped.sv.vcf.gz"
                         ]
                     ]
                 ],
@@ -204,12 +204,12 @@
                         [
                             "test_1_reheader.vcf.gz",
                             "VcfFile [chromosomes=[chrX, chr16], sampleCount=1, variantCount=36, phased=false, phasedAutodetect=false]",
-                            "58ceb0e313053625db9972c69b144ad0"
+                            "6725794c7b57e4a6fab095b38057be69"
                         ],
                         [
                             "test_2_reheader.vcf.gz",
                             "VcfFile [chromosomes=[chr16], sampleCount=1, variantCount=31, phased=false, phasedAutodetect=false]",
-                            "681741ccb15d23e69a9d43e6ed7e6f72"
+                            "89da55ac301e9ea86b07955924411ec6"
                         ]
                     ]
                 ],
@@ -223,21 +223,21 @@
                         [
                             "test_1_reheader.vcf.gz",
                             "VcfFile [chromosomes=[chrX, chr16, chr17, chrM, chr20], sampleCount=1, variantCount=21, phased=false, phasedAutodetect=false]",
-                            "6027977b1608ebac435f587bf0ec2261"
+                            "16a6a94720e70c3b838d14d67d74029b"
                         ],
                         [
                             "test_2_reheader.vcf.gz",
                             "VcfFile [chromosomes=[chr16, chr17, chr20], sampleCount=1, variantCount=4, phased=false, phasedAutodetect=false]",
-                            "c6a5b93c6ba8b42a034f3c5b4ce003d"
+                            "20a871dd68d402735b2de3d8bd6f3fd"
                         ]
                     ]
                 ]
             ]
         ],
-        "timestamp": "2026-08-06T13:26:09.378504416",
+        "timestamp": "2026-08-13T09:13:40.950276745",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.07.0"
+            "nextflow": "26.04.6"
         }
     },
     "2 samples, 1 family - sniffes,severus with trf bed, run all callers - stub": {
@@ -250,8 +250,8 @@
                             "sv_caller": "hificnv"
                         },
                         [
-                            "test_1_hificnv_found_in.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_2_hificnv_found_in.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                            "test_1_hificnv.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2_hificnv.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                         ]
                     ],
                     [
@@ -349,10 +349,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-06T14:08:02.726073892",
+        "timestamp": "2026-08-13T09:17:07.14067252",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.07.0"
+            "nextflow": "26.04.6"
         }
     },
     "2 samples, 1 family - merge sniffes,hificnv,severus,sawfish with trf bed, run all callers and filter": {
@@ -366,10 +366,10 @@
                     },
                     [
                         [
-                            "test_1_hificnv_found_in.vcf.gz"
+                            "test_1_hificnv_filtered.vcf.gz"
                         ],
                         [
-                            "test_2_hificnv_found_in.vcf.gz"
+                            "test_2_hificnv_filtered.vcf.gz"
                         ]
                     ]
                 ],
@@ -381,7 +381,7 @@
                     },
                     [
                         [
-                            "family_sawfish_found_in.vcf.gz"
+                            "family_sawfish_filtered.vcf.gz"
                         ]
                     ]
                 ],
@@ -395,12 +395,12 @@
                         [
                             "test_1_reheader.vcf.gz",
                             "VcfFile [chromosomes=[chr16], sampleCount=1, variantCount=1, phased=false, phasedAutodetect=false]",
-                            "ae1e654608d3aa822ba69b57ce31a861"
+                            "62cf182304490e1ecd958247dc8e8727"
                         ],
                         [
                             "test_2_reheader.vcf.gz",
                             "VcfFile [chromosomes=[chr16], sampleCount=1, variantCount=1, phased=false, phasedAutodetect=false]",
-                            "ea83940547c0bc15eb6b4c9a59159406"
+                            "582b249ead6e03350420af97130b92be"
                         ]
                     ]
                 ],
@@ -414,7 +414,7 @@
                         [
                             "test_1_reheader.vcf.gz",
                             "VcfFile [chromosomes=[chr16], sampleCount=1, variantCount=1, phased=false, phasedAutodetect=false]",
-                            "1b214fb9e1e9bcc3d7719580c2a6bbc6"
+                            "b5b3aad900660c9b5f9ea6d412e631ff"
                         ],
                         [
                             "test_2_reheader.vcf.gz",
@@ -425,10 +425,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-08-06T13:27:40.497040066",
+        "timestamp": "2026-08-13T09:15:56.648454674",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.07.0"
+            "nextflow": "26.04.6"
         }
     },
     "1 sample, 1 family - sawfish, force_sawfish_joint_call_single_samples true": {
@@ -442,16 +442,16 @@
                     },
                     [
                         [
-                            "test_1_sawfish_found_in.vcf.gz"
+                            "test_1_sawfish_jointcall_genotyped.sv.vcf.gz"
                         ]
                     ]
                 ]
             ]
         ],
-        "timestamp": "2026-08-06T13:25:21.609114442",
+        "timestamp": "2026-08-13T09:12:44.88671821",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.07.0"
+            "nextflow": "26.04.6"
         }
     },
     "1 sample, 1 family - sawfish, force_sawfish_joint_call_single_samples true -stub": {
@@ -464,7 +464,7 @@
                             "sv_caller": "sawfish"
                         },
                         [
-                            "family_sawfish_found_in.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                            "family_sawfish_jointcall_genotyped.sv.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                         ]
                     ]
                 ],
@@ -515,10 +515,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-06T14:08:19.012912595",
+        "timestamp": "2026-08-13T09:17:21.451845377",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.07.0"
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/subworkflows/local/call_svs/tests/nextflow.config
+++ b/subworkflows/local/call_svs/tests/nextflow.config
@@ -1,15 +1,5 @@
 process {
 
-    withName: 'CALL_SVS:VCFEXPRESS' {
-        ext.prefix = { "${meta.id}_${meta.sv_caller}_found_in" }
-        ext.suffix = { "vcf.gz" }
-        ext.args   = { "-s \'FOUND_IN=return \"${meta.sv_caller}\"\' -e \"return true\"" }
-    }
-
-    withName: 'CALL_SVS:TABIX_VCFEXPRESS' {
-        ext.prefix = { "${meta.id}_${meta.sv_caller}" }
-    }
-
     withName: 'CALL_SVS:VEP_PREP_SV' {
         ext.prefix = { "${meta.id}_vep_prep" }
         ext.args   = { meta.sv_caller == 'sniffles' ? '--caller sniffles1' : '' }

--- a/subworkflows/local/merge_svs/main.nf
+++ b/subworkflows/local/merge_svs/main.nf
@@ -1,11 +1,13 @@
 include { SVDB_MERGE as SVDB_MERGE_BY_CALLER } from '../../../modules/nf-core/svdb/merge/main'
 include { SVDB_MERGE as SVDB_MERGE_BY_FAMILY } from '../../../modules/nf-core/svdb/merge/main'
+include { VCFEXPRESS                         } from '../../../modules/nf-core/vcfexpress/main'
 
 workflow MERGE_SVS {
     take:
     ch_vcf // channel: [ val(meta), [ path(vcf) ] ]
     sv_callers_to_merge // List: [ 'caller1', 'caller2', 'caller3' ]
     caller_priority // List: [ 'caller3', 'caller1', 'caller2' ]
+    ch_vcfexpress_prelude // path: lua file
 
     main:
     /*
@@ -20,12 +22,18 @@ workflow MERGE_SVS {
         true,
     )
 
+    // Add FOUND_IN INFO tag to each per-caller family VCF
+    VCFEXPRESS(
+        SVDB_MERGE_BY_CALLER.out.vcf,
+        ch_vcfexpress_prelude,
+    )
+
     /*
      * Then merge the family VCFs for each caller into a single family VCF.
      * First we need to filter the SV callers to merge,
      * Then we need to group by family (meta.id), and sort the VCFs by the caller priority for SVDB merge.
      */
-    ch_svdb_merge_by_family_input = SVDB_MERGE_BY_CALLER.out.vcf
+    ch_svdb_merge_by_family_input = VCFEXPRESS.out.vcf
         .filter { meta, _vcf ->
             sv_callers_to_merge.contains(meta.sv_caller)
         }

--- a/subworkflows/local/merge_svs/tests/main.nf.test
+++ b/subworkflows/local/merge_svs/tests/main.nf.test
@@ -18,6 +18,7 @@ nextflow_workflow {
                 )
                 input[1] = ['sniffles']
                 input[2] = ['sniffles']
+                input[3] = file('../../../assets/vcf_express_found_in_prelude.lua')
                 """
             }
         }
@@ -52,6 +53,7 @@ nextflow_workflow {
                 )
                 input[1] = ['sniffles', 'severus', 'hificnv', 'sawfish']
                 input[2] = ['sniffles', 'severus', 'hificnv', 'sawfish']
+                input[3] = file('../../../assets/vcf_express_found_in_prelude.lua')
                 """
             }
         }
@@ -88,6 +90,7 @@ nextflow_workflow {
                 )
                 input[1] = ['sniffles', 'severus', 'hificnv', 'sawfish']
                 input[2] = ['sniffles', 'severus', 'hificnv', 'sawfish']
+                input[3] = file('../../../assets/vcf_express_found_in_prelude.lua')
                 """
             }
         }

--- a/subworkflows/local/merge_svs/tests/nextflow.config
+++ b/subworkflows/local/merge_svs/tests/nextflow.config
@@ -1,15 +1,15 @@
 process {
 
-    withName: 'MERGE_SVS:VCFEXPRESS' {
-        ext.prefix = { "${meta.id}_${meta.sv_caller}_found_in" }
-        ext.suffix = { "vcf.gz" }
-        ext.args   = { "-s \'FOUND_IN=return \"${meta.sv_caller}\"\' -e \"return true\"" }
-    }
-
     withName: 'MERGE_SVS:SVDB_MERGE_BY_CALLER' {
         ext.prefix = { "${meta.sv_caller}_svdb_merge_by_caller" }
         ext.args   = ['--bnd_distance 1000', '--overlap .5'].join(' ')
         ext.args2  = ['--output-type z', '--write-index=tbi', '--no-version'].join(' ')
+    }
+
+    withName: 'MERGE_SVS:VCFEXPRESS' {
+        ext.prefix = { "${meta.id}_${meta.sv_caller}_found_in" }
+        ext.suffix = { "vcf.gz" }
+        ext.args   = { "-s \'FOUND_IN=return \"${meta.sv_caller}\"\' -e \"return true\"" }
     }
 
     withName: 'MERGE_SVS:SVDB_MERGE_BY_FAMILY' {

--- a/subworkflows/local/merge_svs/tests/nextflow.config
+++ b/subworkflows/local/merge_svs/tests/nextflow.config
@@ -1,5 +1,11 @@
 process {
 
+    withName: 'MERGE_SVS:VCFEXPRESS' {
+        ext.prefix = { "${meta.id}_${meta.sv_caller}_found_in" }
+        ext.suffix = { "vcf.gz" }
+        ext.args   = { "-s \'FOUND_IN=return \"${meta.sv_caller}\"\' -e \"return true\"" }
+    }
+
     withName: 'MERGE_SVS:SVDB_MERGE_BY_CALLER' {
         ext.prefix = { "${meta.sv_caller}_svdb_merge_by_caller" }
         ext.args   = ['--bnd_distance 1000', '--overlap .5'].join(' ')

--- a/tests/samplesheet_multisample_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_bam.nf.test.snap
@@ -1130,8 +1130,8 @@
                 "HG004_pbcpgtools.hap1.bed.gz.tbi:md5,024664fdd990e560c75996cbd7de4b5a",
                 "HG004_pbcpgtools.hap2.bed.gz:md5,06de0befc807d3107a47597f8a2984b6",
                 "HG004_pbcpgtools.hap2.bed.gz.tbi:md5,7590c937d683905d8f41d35758a3780e",
-                "bcftools-stats-subtypes.txt:md5,7ff0d336d225e77c4bc70d8c24a5eed1",
-                "bcftools_stats_indel-lengths.txt:md5,2947390673d791003d48a676e7095739",
+                "bcftools-stats-subtypes.txt:md5,fb23dc7e6352cb80cac687458c3b7eb6",
+                "bcftools_stats_indel-lengths.txt:md5,90119ecff77f267e56e987430aafcb4c",
                 "fastqc-status-check-heatmap.txt:md5,f67860347368dd43ec3be3a53e1085dc",
                 "fastqc_adapter_content_plot.txt:md5,977a14d0a229fb62fa79426bc8d79534",
                 "fastqc_overrepresented_sequences_plot.txt:md5,39f5feb1737b248e86b9b39a1d043879",
@@ -1148,10 +1148,10 @@
                 "mosdepth_cov_dist.txt:md5,89dfdf2287ed8e395284643954556cb1",
                 "mosdepth_cumcov_dist.txt:md5,89dfdf2287ed8e395284643954556cb1",
                 "mosdepth_perchrom.txt:md5,4890c63101272eb3ff304178a32a836a",
-                "multiqc_bcftools_stats.txt:md5,76f588ad3f387f15f8bb15301a16adf1",
+                "multiqc_bcftools_stats.txt:md5,6f45f8818c190b7d60ea602a1c1887de",
                 "multiqc_citations.txt:md5,b3367d20aa6e8306ca1c32c0f5993899",
                 "multiqc_fastqc.txt:md5,ace1ff42b44a8ec24ede4837f85f65d8",
-                "multiqc_general_stats.txt:md5,ca0db4f26f60e74a2a6e854f092821ed",
+                "multiqc_general_stats.txt:md5,1291eea7b3e9725b9ea63db5e231baab",
                 "multiqc_whatshap_phased_bp_plot.txt:md5,5367473f043564c1995035e669f25b76",
                 "peddy_relatedness_plot.txt:md5,38bbf220ffc042cfa5d4696fccda3f55",
                 "somalier_stats.txt:md5,a6119aecaa54536d9b358b7feba7841a",
@@ -1343,7 +1343,7 @@
                 
             ]
         ],
-        "timestamp": "2026-08-13T10:29:57.996762979",
+        "timestamp": "2026-08-13T11:39:26.047994664",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/samplesheet_multisample_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_bam.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "samplesheet_multisample_bam": {
         "content": [
-            429,
+            423,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -1130,8 +1130,8 @@
                 "HG004_pbcpgtools.hap1.bed.gz.tbi:md5,024664fdd990e560c75996cbd7de4b5a",
                 "HG004_pbcpgtools.hap2.bed.gz:md5,06de0befc807d3107a47597f8a2984b6",
                 "HG004_pbcpgtools.hap2.bed.gz.tbi:md5,7590c937d683905d8f41d35758a3780e",
-                "bcftools-stats-subtypes.txt:md5,fb23dc7e6352cb80cac687458c3b7eb6",
-                "bcftools_stats_indel-lengths.txt:md5,90119ecff77f267e56e987430aafcb4c",
+                "bcftools-stats-subtypes.txt:md5,7ff0d336d225e77c4bc70d8c24a5eed1",
+                "bcftools_stats_indel-lengths.txt:md5,2947390673d791003d48a676e7095739",
                 "fastqc-status-check-heatmap.txt:md5,f67860347368dd43ec3be3a53e1085dc",
                 "fastqc_adapter_content_plot.txt:md5,977a14d0a229fb62fa79426bc8d79534",
                 "fastqc_overrepresented_sequences_plot.txt:md5,39f5feb1737b248e86b9b39a1d043879",
@@ -1148,10 +1148,10 @@
                 "mosdepth_cov_dist.txt:md5,89dfdf2287ed8e395284643954556cb1",
                 "mosdepth_cumcov_dist.txt:md5,89dfdf2287ed8e395284643954556cb1",
                 "mosdepth_perchrom.txt:md5,4890c63101272eb3ff304178a32a836a",
-                "multiqc_bcftools_stats.txt:md5,6f45f8818c190b7d60ea602a1c1887de",
+                "multiqc_bcftools_stats.txt:md5,76f588ad3f387f15f8bb15301a16adf1",
                 "multiqc_citations.txt:md5,b3367d20aa6e8306ca1c32c0f5993899",
                 "multiqc_fastqc.txt:md5,ace1ff42b44a8ec24ede4837f85f65d8",
-                "multiqc_general_stats.txt:md5,1291eea7b3e9725b9ea63db5e231baab",
+                "multiqc_general_stats.txt:md5,ca0db4f26f60e74a2a6e854f092821ed",
                 "multiqc_whatshap_phased_bp_plot.txt:md5,5367473f043564c1995035e669f25b76",
                 "peddy_relatedness_plot.txt:md5,38bbf220ffc042cfa5d4696fccda3f55",
                 "somalier_stats.txt:md5,a6119aecaa54536d9b358b7feba7841a",
@@ -1343,7 +1343,7 @@
                 
             ]
         ],
-        "timestamp": "2026-08-12T11:50:39.555700642",
+        "timestamp": "2026-08-13T10:29:57.996762979",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/samplesheet_multisample_ont_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_ont_bam.nf.test.snap
@@ -1023,8 +1023,8 @@
                 "HG002_ONT_C_modkit_pileup_hp1.bed.gz.tbi:md5,64f5cfd6919e2302bfd311d09c98a58b",
                 "HG002_ONT_C_modkit_pileup_hp2.bed.gz:md5,da977fec1c09e4870eb91e260c3cc085",
                 "HG002_ONT_C_modkit_pileup_hp2.bed.gz.tbi:md5,da42a56d8b9b363c34cafa38dd42b313",
-                "bcftools-stats-subtypes.txt:md5,e2d573ed3796fce68c49eada50d7b8c2",
-                "bcftools_stats_indel-lengths.txt:md5,9936cc7db63b9d669b6308751f635aba",
+                "bcftools-stats-subtypes.txt:md5,f81ccaf1c17d78b51680366e935dd0c2",
+                "bcftools_stats_indel-lengths.txt:md5,110a020ff88a98450c422ab7c2c490e9",
                 "fastqc-status-check-heatmap.txt:md5,4ef2e67a5ed003db72cf8d4d86b01285",
                 "fastqc_adapter_content_plot.txt:md5,706344bf7a6f7c72ec278b44ccc1bf9a",
                 "fastqc_overrepresented_sequences_plot.txt:md5,4793807805fd02d81f49849ef493db14",
@@ -1041,10 +1041,10 @@
                 "mosdepth_cov_dist.txt:md5,34d42c2b23250d289ce2c0adf394891f",
                 "mosdepth_cumcov_dist.txt:md5,34d42c2b23250d289ce2c0adf394891f",
                 "mosdepth_perchrom.txt:md5,ca490536a8c80cf070199755d8c61eb0",
-                "multiqc_bcftools_stats.txt:md5,fba914d91a1df00b6fedab048a4c777a",
+                "multiqc_bcftools_stats.txt:md5,ad4f3c2407fcdbc530e64ebe402902a7",
                 "multiqc_citations.txt:md5,b3367d20aa6e8306ca1c32c0f5993899",
                 "multiqc_fastqc.txt:md5,45c48809ef207ece2422fa33a86c30c7",
-                "multiqc_general_stats.txt:md5,dabec214578e7804b9af40ce65d78f37",
+                "multiqc_general_stats.txt:md5,aa04b8f4825dadb4206efb3d15463bf9",
                 "multiqc_whatshap_phased_bp_plot.txt:md5,f644fc0ce39328719b84c83f9517f3b1",
                 "peddy_relatedness_plot.txt:md5,c180406a5f106d03fa7c96a3cf188a7d",
                 "somalier_stats.txt:md5,b169a23cecd1d3b1e79d0f615073c5dc",
@@ -1230,7 +1230,7 @@
                 
             ]
         ],
-        "timestamp": "2026-08-13T10:34:07.566245878",
+        "timestamp": "2026-08-13T11:43:28.642157107",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/samplesheet_multisample_ont_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_ont_bam.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "samplesheet_multisample_ont_bam | --preset ONT_R10 --phaser whatshap --alignment_processes 1 --snv_calling_processes 1 --sv_caller sniffles --publish_unannotated_family_svs": {
         "content": [
-            342,
+            339,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -1023,8 +1023,8 @@
                 "HG002_ONT_C_modkit_pileup_hp1.bed.gz.tbi:md5,64f5cfd6919e2302bfd311d09c98a58b",
                 "HG002_ONT_C_modkit_pileup_hp2.bed.gz:md5,da977fec1c09e4870eb91e260c3cc085",
                 "HG002_ONT_C_modkit_pileup_hp2.bed.gz.tbi:md5,da42a56d8b9b363c34cafa38dd42b313",
-                "bcftools-stats-subtypes.txt:md5,f81ccaf1c17d78b51680366e935dd0c2",
-                "bcftools_stats_indel-lengths.txt:md5,110a020ff88a98450c422ab7c2c490e9",
+                "bcftools-stats-subtypes.txt:md5,e2d573ed3796fce68c49eada50d7b8c2",
+                "bcftools_stats_indel-lengths.txt:md5,9936cc7db63b9d669b6308751f635aba",
                 "fastqc-status-check-heatmap.txt:md5,4ef2e67a5ed003db72cf8d4d86b01285",
                 "fastqc_adapter_content_plot.txt:md5,706344bf7a6f7c72ec278b44ccc1bf9a",
                 "fastqc_overrepresented_sequences_plot.txt:md5,4793807805fd02d81f49849ef493db14",
@@ -1041,10 +1041,10 @@
                 "mosdepth_cov_dist.txt:md5,34d42c2b23250d289ce2c0adf394891f",
                 "mosdepth_cumcov_dist.txt:md5,34d42c2b23250d289ce2c0adf394891f",
                 "mosdepth_perchrom.txt:md5,ca490536a8c80cf070199755d8c61eb0",
-                "multiqc_bcftools_stats.txt:md5,ad4f3c2407fcdbc530e64ebe402902a7",
+                "multiqc_bcftools_stats.txt:md5,fba914d91a1df00b6fedab048a4c777a",
                 "multiqc_citations.txt:md5,b3367d20aa6e8306ca1c32c0f5993899",
                 "multiqc_fastqc.txt:md5,45c48809ef207ece2422fa33a86c30c7",
-                "multiqc_general_stats.txt:md5,aa04b8f4825dadb4206efb3d15463bf9",
+                "multiqc_general_stats.txt:md5,dabec214578e7804b9af40ce65d78f37",
                 "multiqc_whatshap_phased_bp_plot.txt:md5,f644fc0ce39328719b84c83f9517f3b1",
                 "peddy_relatedness_plot.txt:md5,c180406a5f106d03fa7c96a3cf188a7d",
                 "somalier_stats.txt:md5,b169a23cecd1d3b1e79d0f615073c5dc",
@@ -1230,7 +1230,7 @@
                 
             ]
         ],
-        "timestamp": "2026-08-12T11:55:16.032440508",
+        "timestamp": "2026-08-13T10:34:07.566245878",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/samplesheet_multisample_ont_bam_ont_r10_as.nf.test.snap
+++ b/tests/samplesheet_multisample_ont_bam_ont_r10_as.nf.test.snap
@@ -953,8 +953,8 @@
                 "HG002_ONT_C_modkit_pileup_hp1.bed.gz.tbi:md5,64f5cfd6919e2302bfd311d09c98a58b",
                 "HG002_ONT_C_modkit_pileup_hp2.bed.gz:md5,da977fec1c09e4870eb91e260c3cc085",
                 "HG002_ONT_C_modkit_pileup_hp2.bed.gz.tbi:md5,da42a56d8b9b363c34cafa38dd42b313",
-                "bcftools-stats-subtypes.txt:md5,e2d573ed3796fce68c49eada50d7b8c2",
-                "bcftools_stats_indel-lengths.txt:md5,9936cc7db63b9d669b6308751f635aba",
+                "bcftools-stats-subtypes.txt:md5,f81ccaf1c17d78b51680366e935dd0c2",
+                "bcftools_stats_indel-lengths.txt:md5,110a020ff88a98450c422ab7c2c490e9",
                 "fastqc-status-check-heatmap.txt:md5,4ef2e67a5ed003db72cf8d4d86b01285",
                 "fastqc_adapter_content_plot.txt:md5,68a9946cf1472eb1b02108c6f2d95ea5",
                 "fastqc_overrepresented_sequences_plot.txt:md5,efc1254d2b1dd306ea0f2ceaa78654d8",
@@ -971,10 +971,10 @@
                 "mosdepth_cov_dist.txt:md5,c3cd360825f57fb30280ea8d239d0b01",
                 "mosdepth_cumcov_dist.txt:md5,c3cd360825f57fb30280ea8d239d0b01",
                 "mosdepth_perchrom.txt:md5,0e09fb1dc32d8a9c91df304c8a0e7bf3",
-                "multiqc_bcftools_stats.txt:md5,fba914d91a1df00b6fedab048a4c777a",
+                "multiqc_bcftools_stats.txt:md5,ad4f3c2407fcdbc530e64ebe402902a7",
                 "multiqc_citations.txt:md5,fd94ebcbd9e5bbdf8757b8873e5bf3e0",
                 "multiqc_fastqc.txt:md5,d35b5896e9582af1c1a57716dd2cf7ba",
-                "multiqc_general_stats.txt:md5,2f5e9f4bae4dbc02dbc8fade20ae86d9",
+                "multiqc_general_stats.txt:md5,ca3b2be9758ae398178fe35c84a80b9d",
                 "multiqc_whatshap_phased_bp_plot.txt:md5,f644fc0ce39328719b84c83f9517f3b1",
                 "peddy_relatedness_plot.txt:md5,c180406a5f106d03fa7c96a3cf188a7d",
                 "whatshap-stats-table.txt:md5,f9313dcc3c901abb055dda4850dc255e",
@@ -1153,7 +1153,7 @@
                 
             ]
         ],
-        "timestamp": "2026-08-13T10:38:34.749367193",
+        "timestamp": "2026-08-13T11:57:05.534746258",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/samplesheet_multisample_ont_bam_ont_r10_as.nf.test.snap
+++ b/tests/samplesheet_multisample_ont_bam_ont_r10_as.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "samplesheet_multisample_ont_bam | --preset ONT_R10_AS --target_regions test_data.bed --phaser whatshap --alignment_processes 1 --snv_calling_processes 1": {
         "content": [
-            306,
+            303,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -953,8 +953,8 @@
                 "HG002_ONT_C_modkit_pileup_hp1.bed.gz.tbi:md5,64f5cfd6919e2302bfd311d09c98a58b",
                 "HG002_ONT_C_modkit_pileup_hp2.bed.gz:md5,da977fec1c09e4870eb91e260c3cc085",
                 "HG002_ONT_C_modkit_pileup_hp2.bed.gz.tbi:md5,da42a56d8b9b363c34cafa38dd42b313",
-                "bcftools-stats-subtypes.txt:md5,f81ccaf1c17d78b51680366e935dd0c2",
-                "bcftools_stats_indel-lengths.txt:md5,110a020ff88a98450c422ab7c2c490e9",
+                "bcftools-stats-subtypes.txt:md5,e2d573ed3796fce68c49eada50d7b8c2",
+                "bcftools_stats_indel-lengths.txt:md5,9936cc7db63b9d669b6308751f635aba",
                 "fastqc-status-check-heatmap.txt:md5,4ef2e67a5ed003db72cf8d4d86b01285",
                 "fastqc_adapter_content_plot.txt:md5,68a9946cf1472eb1b02108c6f2d95ea5",
                 "fastqc_overrepresented_sequences_plot.txt:md5,efc1254d2b1dd306ea0f2ceaa78654d8",
@@ -971,10 +971,10 @@
                 "mosdepth_cov_dist.txt:md5,c3cd360825f57fb30280ea8d239d0b01",
                 "mosdepth_cumcov_dist.txt:md5,c3cd360825f57fb30280ea8d239d0b01",
                 "mosdepth_perchrom.txt:md5,0e09fb1dc32d8a9c91df304c8a0e7bf3",
-                "multiqc_bcftools_stats.txt:md5,ad4f3c2407fcdbc530e64ebe402902a7",
+                "multiqc_bcftools_stats.txt:md5,fba914d91a1df00b6fedab048a4c777a",
                 "multiqc_citations.txt:md5,fd94ebcbd9e5bbdf8757b8873e5bf3e0",
                 "multiqc_fastqc.txt:md5,d35b5896e9582af1c1a57716dd2cf7ba",
-                "multiqc_general_stats.txt:md5,ca3b2be9758ae398178fe35c84a80b9d",
+                "multiqc_general_stats.txt:md5,2f5e9f4bae4dbc02dbc8fade20ae86d9",
                 "multiqc_whatshap_phased_bp_plot.txt:md5,f644fc0ce39328719b84c83f9517f3b1",
                 "peddy_relatedness_plot.txt:md5,c180406a5f106d03fa7c96a3cf188a7d",
                 "whatshap-stats-table.txt:md5,f9313dcc3c901abb055dda4850dc255e",
@@ -1153,7 +1153,7 @@
                 
             ]
         ],
-        "timestamp": "2026-08-12T11:59:19.561447221",
+        "timestamp": "2026-08-13T10:38:34.749367193",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/samplesheet_premapped.nf.test.snap
+++ b/tests/samplesheet_premapped.nf.test.snap
@@ -1044,8 +1044,8 @@
                 "HG004_pbcpgtools.hap1.bed.gz.tbi:md5,9ca325d628193be17d26db9c9212b09b",
                 "HG004_pbcpgtools.hap2.bed.gz:md5,6c45c517f75ff2801ebe4422f16c84ad",
                 "HG004_pbcpgtools.hap2.bed.gz.tbi:md5,421a662d9bba3328a2a53131d99ab707",
-                "bcftools-stats-subtypes.txt:md5,a224445b24151b7bf41893ca532ef866",
-                "bcftools_stats_indel-lengths.txt:md5,7db931100546f3ac2999d92b6ca61a34",
+                "bcftools-stats-subtypes.txt:md5,9a5918630790359c9f56c583b6cf0c9a",
+                "bcftools_stats_indel-lengths.txt:md5,518d9c0612ee3772bd13e269cb929772",
                 "fastqc-status-check-heatmap.txt:md5,f67860347368dd43ec3be3a53e1085dc",
                 "fastqc_adapter_content_plot.txt:md5,27001dc0f94066ef56d3c49a71f7d0cc",
                 "fastqc_overrepresented_sequences_plot.txt:md5,d8125f2a6525ff73700b9d1dac88095c",
@@ -1062,10 +1062,10 @@
                 "mosdepth_cov_dist.txt:md5,529251eb84817d1346184d21a0a15511",
                 "mosdepth_cumcov_dist.txt:md5,529251eb84817d1346184d21a0a15511",
                 "mosdepth_perchrom.txt:md5,3028e766c7dac25271ae85dd3530c2f6",
-                "multiqc_bcftools_stats.txt:md5,881e73457fe2b72011ecaaae6a9a0b91",
+                "multiqc_bcftools_stats.txt:md5,bde59835db1cd3f3282d0e3c128dba2c",
                 "multiqc_citations.txt:md5,b3367d20aa6e8306ca1c32c0f5993899",
                 "multiqc_fastqc.txt:md5,1672c3d8b4e5948f08d17af808872dc9",
-                "multiqc_general_stats.txt:md5,f6258d36a96ee618f7216b02fa3049a8",
+                "multiqc_general_stats.txt:md5,a44e9bd29f3bc17040c68530d45e8456",
                 "multiqc_whatshap_phased_bp_plot.txt:md5,84b18ab73d2569912d69a20b3b2bf869",
                 "peddy_relatedness_plot.txt:md5,ccb7576c82712746a7805e4b08f8de11",
                 "somalier_stats.txt:md5,22bd1aabdb8da1fe0e49f5a4469bdf79",
@@ -1236,7 +1236,7 @@
                 
             ]
         ],
-        "timestamp": "2026-08-13T10:42:39.040927985",
+        "timestamp": "2026-08-13T12:04:49.776486434",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/samplesheet_premapped.nf.test.snap
+++ b/tests/samplesheet_premapped.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "samplesheet_premapped | --premapped": {
         "content": [
-            361,
+            355,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -1044,8 +1044,8 @@
                 "HG004_pbcpgtools.hap1.bed.gz.tbi:md5,9ca325d628193be17d26db9c9212b09b",
                 "HG004_pbcpgtools.hap2.bed.gz:md5,6c45c517f75ff2801ebe4422f16c84ad",
                 "HG004_pbcpgtools.hap2.bed.gz.tbi:md5,421a662d9bba3328a2a53131d99ab707",
-                "bcftools-stats-subtypes.txt:md5,9a5918630790359c9f56c583b6cf0c9a",
-                "bcftools_stats_indel-lengths.txt:md5,518d9c0612ee3772bd13e269cb929772",
+                "bcftools-stats-subtypes.txt:md5,a224445b24151b7bf41893ca532ef866",
+                "bcftools_stats_indel-lengths.txt:md5,7db931100546f3ac2999d92b6ca61a34",
                 "fastqc-status-check-heatmap.txt:md5,f67860347368dd43ec3be3a53e1085dc",
                 "fastqc_adapter_content_plot.txt:md5,27001dc0f94066ef56d3c49a71f7d0cc",
                 "fastqc_overrepresented_sequences_plot.txt:md5,d8125f2a6525ff73700b9d1dac88095c",
@@ -1062,10 +1062,10 @@
                 "mosdepth_cov_dist.txt:md5,529251eb84817d1346184d21a0a15511",
                 "mosdepth_cumcov_dist.txt:md5,529251eb84817d1346184d21a0a15511",
                 "mosdepth_perchrom.txt:md5,3028e766c7dac25271ae85dd3530c2f6",
-                "multiqc_bcftools_stats.txt:md5,bde59835db1cd3f3282d0e3c128dba2c",
+                "multiqc_bcftools_stats.txt:md5,881e73457fe2b72011ecaaae6a9a0b91",
                 "multiqc_citations.txt:md5,b3367d20aa6e8306ca1c32c0f5993899",
                 "multiqc_fastqc.txt:md5,1672c3d8b4e5948f08d17af808872dc9",
-                "multiqc_general_stats.txt:md5,a44e9bd29f3bc17040c68530d45e8456",
+                "multiqc_general_stats.txt:md5,f6258d36a96ee618f7216b02fa3049a8",
                 "multiqc_whatshap_phased_bp_plot.txt:md5,84b18ab73d2569912d69a20b3b2bf869",
                 "peddy_relatedness_plot.txt:md5,ccb7576c82712746a7805e4b08f8de11",
                 "somalier_stats.txt:md5,22bd1aabdb8da1fe0e49f5a4469bdf79",
@@ -1236,7 +1236,7 @@
                 
             ]
         ],
-        "timestamp": "2026-08-12T12:02:28.397160415",
+        "timestamp": "2026-08-13T10:42:39.040927985",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/stub_ont_r10_as_preset.nf.test.snap
+++ b/tests/stub_ont_r10_as_preset.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "ONT_R10_AS preset with target_regions filters reads to regions before cramino QC and applies correct preset defaults": {
         "content": [
-            191,
+            188,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -433,7 +433,7 @@
                 "visualization_tracks/HG002_ONT_C/HG002_ONT_C_hificnv.maf.bw"
             ]
         ],
-        "timestamp": "2026-08-12T16:03:37.281752714",
+        "timestamp": "2026-08-13T10:12:25.46521397",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/workflows/nallo.nf
+++ b/workflows/nallo.nf
@@ -652,13 +652,13 @@ workflow NALLO {
             val_force_sawfish_joint_call_single_samples,
             val_create_hificnv_maf_track,
             val_create_sawfish_maf_track,
-            ch_vcfexpress_prelude,
         )
 
         MERGE_SVS(
             CALL_SVS.out.vcf,
             val_sv_callers_to_merge.split(',').collect { caller -> caller.toLowerCase().trim() },
             val_sv_callers_merge_priority.split(',').collect { caller -> caller.toLowerCase().trim() },
+            ch_vcfexpress_prelude,
         )
     }
 


### PR DESCRIPTION
## Summary

Moves `VCFEXPRESS` (FOUND_IN INFO tag stamping) from `CALL_SVS` to `MERGE_SVS`, where it runs after `SVDB_MERGE_BY_CALLER`.

- `VCFEXPRESS` now runs N_families × N_callers times instead of N_samples × N_callers
- Mirrors the SNV pattern in `GVCF_GLNEXUS_NORM_VARIANTS` where VCFEXPRESS runs on the merged family VCF
- `ch_vcfexpress_prelude` removed from `CALL_SVS` take:, added to `MERGE_SVS` take:
- Config block moved from `call_svs.config` → `merge_svs.config`
- Dead `TABIX_VCFEXPRESS` include and config block removed from `call_svs` while touching those files

Closes #1229, part of #1136.

## Test plan

- [x] Regenerate `call_svs` and `merge_svs` snapshots on server
- [ ] CI passes on all samplesheet integration tests