### PR TITLE
ci: add Wave context deadline exceeded to transient retry patterns

### DIFF
--- a/.github/actions/nf-test/action.yml
+++ b/.github/actions/nf-test/action.yml
@@ -64,7 +64,7 @@ runs:
 
         set -o pipefail
         if ! run_nf_test 2>&1 | tee nf-test.log; then
-          if grep -iqE "connection reset|Connection timed out|no space left on device|Can't stage file.*https://|file does not exist.*https://|Failed to pull singularity image|unexpected HTTP status: 5" nf-test.log; then
+          if grep -iqE "connection reset|Connection timed out|no space left on device|Can't stage file.*https://|file does not exist.*https://|Failed to pull singularity image|unexpected HTTP status: 5|context deadline exceeded" nf-test.log; then
             echo "::warning::Transient network/disk failure detected — retrying once"
             run_nf_test
           else


### PR DESCRIPTION
## Summary

- Adds `context deadline exceeded` to the transient failure grep pattern in `.github/actions/nf-test/action.yml`
- This error is a Wave/Seqera Docker registry auth timeout (`cerbero.seqera.io`) that is reliably transient - a single retry resolves it