### PR TITLE
Remove BCFTOOLS_VIEW_SV passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,8 +123,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1141](https://github.com/genomic-medicine-sweden/nallo/pull/1141) - Moved merging of vcfs out of `CALL_SVS` in new `MERGE_SVS` subworkflow
 - [#1229](https://github.com/genomic-medicine-sweden/nallo/pull/1229) - Moved `VCFEXPRESS` (FOUND_IN tagging) from `CALL_SVS` to `MERGE_SVS`, running after `SVDB_MERGE_BY_CALLER`
 - [#1232](https://github.com/genomic-medicine-sweden/nallo/pull/1232) - Changed the re-headering of the SV VCFs, now part of a new subworkflow `REHEADER_SV_VCF`
-- [#588](https://github.com/genomic-medicine-sweden/nallo/issues/588) - Replaced `extra_vep_options` with separate `extra_vep_options_snv` and `extra_vep_options_sv` parameters, appended after the core VEP command for each variant type
-- [#588](https://github.com/genomic-medicine-sweden/nallo/issues/588) - Moved enrichment VEP flags (`--appris`, `--biotype`, `--hgvs`, etc.) from the hardcoded core command to the default values of `extra_vep_options_snv` and `extra_vep_options_sv`; the core command now contains only pipeline-critical flags
+- [#1225](https://github.com/genomic-medicine-sweden/nallo/pull/1225) - Replaced `extra_vep_options` with separate `extra_vep_options_snv` and `extra_vep_options_sv` parameters, appended after the core VEP command for each variant type
+- [#1225](https://github.com/genomic-medicine-sweden/nallo/pull/1225) - Moved enrichment VEP flags (`--appris`, `--biotype`, `--hgvs`, etc.) from the hardcoded core command to the default values of `extra_vep_options_snv` and `extra_vep_options_sv`; the core command now contains only pipeline-critical flags
 
 ### Removed
 
@@ -138,8 +138,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1205](https://github.com/genomic-medicine-sweden/nallo/pull/1205) - Removed use of 2 cpus for `GENMOD_MODELS` in `base.config` since the bug was fixed in v.3.12.0
 - [#1222](https://github.com/genomic-medicine-sweden/nallo/pull/1222) - Removed `CLEAN_SNIFFLES` module (replaced by `VEP_PREP_SV`)
 - [#1224](https://github.com/genomic-medicine-sweden/nallo/pull/1224) - Removed hardcoded memory use in config for `RANK_VARIANTS:BCFTOOLS_SORT` since it is already covered by `task.memory` in the module
-- [#588](https://github.com/genomic-medicine-sweden/nallo/issues/588) - Removed `--polyphen p`, `--sift p`, `--humdiv` from the SV VEP core command; these amino-acid substitution predictors produce no meaningful output for SVs
-- [#1114](https://github.com/genomic-medicine-sweden/nallo/issues/1114) - Removed `BCFTOOLS_VIEW_SV` passthrough process; output naming moved to `main.nf` `path {}` closures
+- [#1225](https://github.com/genomic-medicine-sweden/nallo/pull/1225) - Removed `--polyphen p`, `--sift p`, `--humdiv` from the SV VEP core command; these amino-acid substitution predictors produce no meaningful output for SVs
+- [#1236](https://github.com/genomic-medicine-sweden/nallo/pull/1236) - Removed `BCFTOOLS_VIEW_SV` passthrough process; output naming moved to `main.nf` `path {}` closures
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1222](https://github.com/genomic-medicine-sweden/nallo/pull/1222) - Removed `CLEAN_SNIFFLES` module (replaced by `VEP_PREP_SV`)
 - [#1224](https://github.com/genomic-medicine-sweden/nallo/pull/1224) - Removed hardcoded memory use in config for `RANK_VARIANTS:BCFTOOLS_SORT` since it is already covered by `task.memory` in the module
 - [#588](https://github.com/genomic-medicine-sweden/nallo/issues/588) - Removed `--polyphen p`, `--sift p`, `--humdiv` from the SV VEP core command; these amino-acid substitution predictors produce no meaningful output for SVs
+- [#1114](https://github.com/genomic-medicine-sweden/nallo/issues/1114) - Removed `BCFTOOLS_VIEW_SV` passthrough process; output naming moved to `main.nf` `path {}` closures
 
 ### Fixed
 

--- a/conf/modules/nallo.config
+++ b/conf/modules/nallo.config
@@ -60,29 +60,6 @@ process {
         }
     }
 
-    withName: '.*:NALLO:BCFTOOLS_VIEW_SV' {
-        ext.prefix = {
-            def name = []
-            name << "${meta.id}_svs"
-            if (!params.skip_sv_annotation) {
-                name << "annotated"
-            }
-            if (!params.skip_rank_variants) {
-                name << "ranked"
-            }
-            if (meta?.containsKey('set')) {
-                name << "${meta.set}"
-            }
-            return name.join('_')
-        }
-        ext.args   = {
-            [
-                '--output-type z',
-                '--write-index=tbi',
-            ].join(' ')
-        }
-    }
-
     withName: '.*:NALLO:PEDDY' {
         ext.args = { !params.peddy_sites ? '--sites hg38' : '' }
     }

--- a/main.nf
+++ b/main.nf
@@ -867,9 +867,7 @@ output {
     }
     svs_per_family {
         path { meta, file ->
-            def name = "${meta.id}_svs${params.skip_sv_annotation ? '' : '_annotated'}${params.skip_rank_variants ? '' : '_ranked'}${meta?.containsKey('set') ? '_' + meta.set : ''}"
-            def ext = file.name.endsWith('.vcf.gz.tbi') ? 'vcf.gz.tbi' : 'vcf.gz'
-            "svs/family/${meta.id}/${name}.${ext}"
+            file >> "svs/family/${meta.id}/${meta.id}_svs${params.skip_sv_annotation ? '' : '_annotated'}${params.skip_rank_variants ? '' : '_ranked'}${meta?.containsKey('set') ? '_' + meta.set : ''}.${file.name.endsWith('.vcf.gz.tbi') ? 'vcf.gz.tbi' : 'vcf.gz'}"
         }
     }
     svs_per_family_and_caller {

--- a/main.nf
+++ b/main.nf
@@ -866,7 +866,20 @@ output {
         path { meta, _file -> "qc/somalier/relate/${meta.id}/" }
     }
     svs_per_family {
-        path { meta, _file -> "svs/family/${meta.id}/" }
+        path { meta, file ->
+            def name = ["${meta.id}_svs"]
+            if (!params.skip_sv_annotation) {
+                name << "annotated"
+            }
+            if (!params.skip_rank_variants) {
+                name << "ranked"
+            }
+            if (meta?.containsKey('set')) {
+                name << "${meta.set}"
+            }
+            def ext = file.name.endsWith('.vcf.gz.tbi') ? 'vcf.gz.tbi' : 'vcf.gz'
+            file >> "svs/family/${meta.id}/${name.join('_')}.${ext}"
+        }
     }
     svs_per_family_and_caller {
         path { meta, _file -> "svs/family/${meta.id}/" }

--- a/main.nf
+++ b/main.nf
@@ -867,7 +867,7 @@ output {
     }
     svs_per_family {
         path { meta, file ->
-            file >> "svs/family/${meta.id}/${meta.id}_svs${params.skip_sv_annotation ? '' : '_annotated'}${params.skip_rank_variants ? '' : '_ranked'}${meta?.containsKey('set') ? '_' + meta.set : ''}.${file.name.endsWith('.vcf.gz.tbi') ? 'vcf.gz.tbi' : 'vcf.gz'}"
+            file >> "svs/family/${meta.id}/" + "${meta.id}_svs" + "${params.skip_sv_annotation ? '' : '_annotated'}" + "${params.skip_rank_variants ? '' : '_ranked'}" + "${meta?.containsKey('set') ? '_' + meta.set : ''}" + ".${file.name.endsWith('.vcf.gz.tbi') ? 'vcf.gz.tbi' : 'vcf.gz'}"
         }
     }
     svs_per_family_and_caller {

--- a/main.nf
+++ b/main.nf
@@ -867,18 +867,9 @@ output {
     }
     svs_per_family {
         path { meta, file ->
-            def name = ["${meta.id}_svs"]
-            if (!params.skip_sv_annotation) {
-                name << "annotated"
-            }
-            if (!params.skip_rank_variants) {
-                name << "ranked"
-            }
-            if (meta?.containsKey('set')) {
-                name << "${meta.set}"
-            }
+            def name = "${meta.id}_svs${params.skip_sv_annotation ? '' : '_annotated'}${params.skip_rank_variants ? '' : '_ranked'}${meta?.containsKey('set') ? '_' + meta.set : ''}"
             def ext = file.name.endsWith('.vcf.gz.tbi') ? 'vcf.gz.tbi' : 'vcf.gz'
-            file >> "svs/family/${meta.id}/${name.join('_')}.${ext}"
+            "svs/family/${meta.id}/${name}.${ext}"
         }
     }
     svs_per_family_and_caller {

--- a/tests/samplesheet.nf.test.snap
+++ b/tests/samplesheet.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "test profile": {
         "content": [
-            233,
+            231,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -46,9 +46,6 @@
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_PHASING": {
-                    "bcftools": 1.22
-                },
-                "BCFTOOLS_VIEW_SV": {
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_UNCOMPRESS": {
@@ -850,7 +847,7 @@
                 
             ]
         ],
-        "timestamp": "2026-08-12T11:47:04.494404668",
+        "timestamp": "2026-08-18T09:25:17.056768518",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/samplesheet_multisample_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_bam.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "samplesheet_multisample_bam": {
         "content": [
-            423,
+            421,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -43,9 +43,6 @@
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_PHASING": {
-                    "bcftools": 1.22
-                },
-                "BCFTOOLS_VIEW_SV": {
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_UNCOMPRESS": {
@@ -1343,7 +1340,7 @@
                 
             ]
         ],
-        "timestamp": "2026-08-13T11:39:26.047994664",
+        "timestamp": "2026-08-18T09:30:47.392725636",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/samplesheet_multisample_ont_bam.nf.test.snap
+++ b/tests/samplesheet_multisample_ont_bam.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "samplesheet_multisample_ont_bam | --preset ONT_R10 --phaser whatshap --alignment_processes 1 --snv_calling_processes 1 --sv_caller sniffles --publish_unannotated_family_svs": {
         "content": [
-            339,
+            337,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -40,9 +40,6 @@
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_PHASING": {
-                    "bcftools": 1.22
-                },
-                "BCFTOOLS_VIEW_SV": {
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_UNCOMPRESS": {
@@ -1230,7 +1227,7 @@
                 
             ]
         ],
-        "timestamp": "2026-08-13T11:43:28.642157107",
+        "timestamp": "2026-08-18T09:35:06.708541244",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/samplesheet_multisample_ont_bam_ont_r10_as.nf.test.snap
+++ b/tests/samplesheet_multisample_ont_bam_ont_r10_as.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "samplesheet_multisample_ont_bam | --preset ONT_R10_AS --target_regions test_data.bed --phaser whatshap --alignment_processes 1 --snv_calling_processes 1": {
         "content": [
-            303,
+            301,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -40,9 +40,6 @@
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_PHASING": {
-                    "bcftools": 1.22
-                },
-                "BCFTOOLS_VIEW_SV": {
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_UNCOMPRESS": {
@@ -1153,7 +1150,7 @@
                 
             ]
         ],
-        "timestamp": "2026-08-13T11:57:05.534746258",
+        "timestamp": "2026-08-18T09:38:35.417758916",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/samplesheet_premapped.nf.test.snap
+++ b/tests/samplesheet_premapped.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "samplesheet_premapped | --premapped": {
         "content": [
-            355,
+            353,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -46,9 +46,6 @@
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_PHASING": {
-                    "bcftools": 1.22
-                },
-                "BCFTOOLS_VIEW_SV": {
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_UNCOMPRESS": {
@@ -1236,7 +1233,7 @@
                 
             ]
         ],
-        "timestamp": "2026-08-13T12:04:49.776486434",
+        "timestamp": "2026-08-18T09:45:32.877063658",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/stub_ont_r10_as_preset.nf.test.snap
+++ b/tests/stub_ont_r10_as_preset.nf.test.snap
@@ -39,9 +39,6 @@
                 "BCFTOOLS_VIEW_PHASING": {
                     "bcftools": 1.22
                 },
-                "BCFTOOLS_VIEW_SV": {
-                    "bcftools": 1.22
-                },
                 "BEDTOOLS_MERGE": {
                     "bedtools": "2.31.1"
                 },

--- a/tests/stub_ont_r10_as_preset.nf.test.snap
+++ b/tests/stub_ont_r10_as_preset.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "ONT_R10_AS preset with target_regions filters reads to regions before cramino QC and applies correct preset defaults": {
         "content": [
-            188,
+            186,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -430,7 +430,7 @@
                 "visualization_tracks/HG002_ONT_C/HG002_ONT_C_hificnv.maf.bw"
             ]
         ],
-        "timestamp": "2026-08-13T10:12:25.46521397",
+        "timestamp": "2026-08-18T09:11:35.211168901",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/stub_same_family_and_sample_id.nf.test.snap
+++ b/tests/stub_same_family_and_sample_id.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "Test family id same as sample id": {
         "content": [
-            192,
+            190,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -510,7 +510,7 @@
                 "visualization_tracks/HG002_Revio/HG002_Revio_pbcpgtools.hap2.bw"
             ]
         ],
-        "timestamp": "2026-08-12T16:05:29.073888457",
+        "timestamp": "2026-08-18T09:14:28.725651157",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/stub_same_family_and_sample_id.nf.test.snap
+++ b/tests/stub_same_family_and_sample_id.nf.test.snap
@@ -45,9 +45,6 @@
                 "BCFTOOLS_VIEW_PHASING": {
                     "bcftools": 1.22
                 },
-                "BCFTOOLS_VIEW_SV": {
-                    "bcftools": 1.22
-                },
                 "BCFTOOLS_VIEW_UNCOMPRESS": {
                     "bcftools": 1.22
                 },

--- a/tests/stub_sawfish_joint_call_single_sample.nf.test.snap
+++ b/tests/stub_sawfish_joint_call_single_sample.nf.test.snap
@@ -21,9 +21,6 @@
                 "BCFTOOLS_VIEW": {
                     "bcftools": 1.22
                 },
-                "BCFTOOLS_VIEW_SV": {
-                    "bcftools": 1.22
-                },
                 "BEDTOOLS_MERGE": {
                     "bedtools": "2.31.1"
                 },

--- a/tests/stub_sawfish_joint_call_single_sample.nf.test.snap
+++ b/tests/stub_sawfish_joint_call_single_sample.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "Test sawfish with force_sawfish_joint_call_single_samples true": {
         "content": [
-            58,
+            57,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -209,7 +209,7 @@
                 "visualization_tracks/test/test_maf_sawfish.bw"
             ]
         ],
-        "timestamp": "2026-08-12T16:06:17.8498849",
+        "timestamp": "2026-08-18T09:15:22.1740384",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/stub_skip_snv_annotation.nf.test.snap
+++ b/tests/stub_skip_snv_annotation.nf.test.snap
@@ -27,9 +27,6 @@
                 "BCFTOOLS_VIEW": {
                     "bcftools": 1.22
                 },
-                "BCFTOOLS_VIEW_SV": {
-                    "bcftools": 1.22
-                },
                 "BEDTOOLS_MERGE": {
                     "bedtools": "2.31.1"
                 },

--- a/tests/stub_skip_snv_annotation.nf.test.snap
+++ b/tests/stub_skip_snv_annotation.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "Test Chromograph works without SNV annotation": {
         "content": [
-            72,
+            70,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.21
@@ -232,7 +232,7 @@
                 "visualization_tracks/HG002_Revio/HG002_Revio_hificnv.maf.bw"
             ]
         ],
-        "timestamp": "2026-08-12T16:07:12.951990704",
+        "timestamp": "2026-08-18T09:16:15.020287485",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/workflows/nallo.nf
+++ b/workflows/nallo.nf
@@ -60,7 +60,6 @@ include { CREATE_PEDIGREE_FILE as SOMALIER_PED_FAMILY            } from '../modu
 include { BCFTOOLS_CONCAT as BCFTOOLS_CONCAT_PHASING             } from '../modules/nf-core/bcftools/concat/main'
 include { BCFTOOLS_CONCAT as BCFTOOLS_CONCAT_MITO_SNVS           } from '../modules/nf-core/bcftools/concat/main'
 include { BCFTOOLS_VIEW as BCFTOOLS_VIEW_CHROMOGRAPH             } from '../modules/nf-core/bcftools/view/main'
-include { BCFTOOLS_VIEW as BCFTOOLS_VIEW_SV                      } from '../modules/nf-core/bcftools/view/main'
 include { BCFTOOLS_VIEW as BCFTOOLS_VIEW_PHASING                 } from '../modules/nf-core/bcftools/view/main'
 include { MINIMAP2_ALIGN                                         } from '../modules/nf-core/minimap2/align/main'
 include { SAMTOOLS_MERGE                                         } from '../modules/nf-core/samtools/merge/main'
@@ -1035,12 +1034,11 @@ workflow NALLO {
                 ? ANN_CSQ_PLI_SVS.out.vcf
                 : ch_ranked_variants.sv.map { meta, vcf, _tbi -> [meta, vcf] }
 
-        BCFTOOLS_VIEW_SV(
-            ch_collect_svs.map { meta, vcf -> [meta, vcf, []] },
-            [],
-            [],
-            [],
-        )
+        ch_collect_tbi = val_skip_sv_annotation
+            ? ch_sv_index_for_annotation
+            : val_skip_rank_variants
+                ? ANN_CSQ_PLI_SVS.out.tbi
+                : ch_ranked_variants.sv.map { meta, _vcf, tbi -> [meta, tbi] }
     }
 
     //
@@ -1297,8 +1295,8 @@ workflow NALLO {
     snvs_family_vcf                     = val_skip_snv_calling ? channel.empty() : CONCAT_SORT_RANKED_SNVS.out.vcf // channel: [ val(meta), path(vcf) ]
     svs_per_family_and_caller_tbi       = val_skip_sv_calling ? channel.empty() : MERGE_SVS.out.family_caller_tbi // channel: [ val(meta), path(tbi) ]
     svs_per_family_and_caller_vcf       = val_skip_sv_calling ? channel.empty() : MERGE_SVS.out.family_caller_vcf // channel: [ val(meta), path(vcf) ]
-    svs_per_family_tbi                  = val_skip_sv_calling ? channel.empty() : BCFTOOLS_VIEW_SV.out.tbi // channel: [ val(meta), path(tbi) ]
-    svs_per_family_vcf                  = val_skip_sv_calling ? channel.empty() : BCFTOOLS_VIEW_SV.out.vcf // channel: [ val(meta), path(vcf.gz) ]
+    svs_per_family_tbi                  = val_skip_sv_calling ? channel.empty() : ch_collect_tbi // channel: [ val(meta), path(tbi) ]
+    svs_per_family_vcf                  = val_skip_sv_calling ? channel.empty() : ch_collect_svs // channel: [ val(meta), path(vcf.gz) ]
 }
 
 /**


### PR DESCRIPTION
## What changed

Closes #1114.

`BCFTOOLS_VIEW_SV` was originally needed to compress and index the merged SV VCF before publishing, and its `ext.prefix` closure in `conf/modules/nallo.config` controlled the output filename. Modern Nextflow supports `path {}` output closures in `main.nf` directly, as already used for `visualization_tracks_hificnv` and `visualization_tracks_sawfish`.

- Removed the `BCFTOOLS_VIEW_SV` process call and its `include` from `workflows/nallo.nf`
- Replaced the simple `svs_per_family { path { ... } }` publish directive in `main.nf` with a naming closure that reproduces the identical `{id}_svs[_annotated][_ranked][_{set}]` convention previously handled by `ext.prefix`
- Added a companion `ch_collect_tbi` channel mirroring `ch_collect_svs` through the same annotation/ranking skip-logic branches, so TBI files are published alongside VCFs without a separate index step
- Deleted the `withName: '.*:NALLO:BCFTOOLS_VIEW_SV'` block from `conf/modules/nallo.config`
- Updated stub test snapshots to remove the `BCFTOOLS_VIEW_SV` versions entry (4 stubs updated locally; 6 real integration snapshots need a CI server re-run)