### PR TITLE
Fix syntax that prevents module compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1196](https://github.com/genomic-medicine-sweden/nallo/pull/1196) - Fixed SVDB merge reordering priorities on retries
 - [#1201](https://github.com/genomic-medicine-sweden/nallo/pull/1201) - Fixed nf-test not triggering on configuration file changes
 - [#1140](https://github.com/genomic-medicine-sweden/nallo/pull/1140) - Fixed sorting of mitochondrial vcf
+- [#1243](https://github.com/genomic-medicine-sweden/nallo/pull/1243) - Fixed invalid syntax in `call_methylation_modkit` that prevents module compilation
 
 ### Parameters
 

--- a/subworkflows/local/call_methylation_modkit/main.nf
+++ b/subworkflows/local/call_methylation_modkit/main.nf
@@ -60,7 +60,7 @@ workflow CALL_METHYLATION_MODKIT {
 }
 
 def gzNotEmptyBySize(file_path) {
-    File gzipFile = file_path.toFile()
+    def gzipFile = file_path.toFile()
     // When modkit produces an empty file, its size seems to be 168 bytes
     if (gzipFile.length() > 168) {
         return true

--- a/subworkflows/local/call_methylation_modkit/main.nf
+++ b/subworkflows/local/call_methylation_modkit/main.nf
@@ -60,8 +60,8 @@ workflow CALL_METHYLATION_MODKIT {
 }
 
 def gzNotEmptyBySize(file_path) {
-    def gzipFile: File = file_path.toFile()
-    // When modkit produces an emty file, its size seems to be 168 bytes
+    File gzipFile = file_path.toFile()
+    // When modkit produces an empty file, its size seems to be 168 bytes
     if (gzipFile.length() > 168) {
         return true
     }


### PR DESCRIPTION
## Description
closes https://github.com/genomic-medicine-sweden/nallo/issues/1241
The type annotation with colon syntax is invalid when running with nextflow version 26.04.4 and makes the module compilation fail when running the dev branch. However, the nextflow linter corrects it with the colon. The type annotation was removed and the linter no longer pick it up.
### Fixed

- Groovy syntax in `call_methylation_modkit` `main.nf` in `gzNotEmptyBySize` function

