### PR TITLE
Update hiphase module to fix typo in hiphase command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1232](https://github.com/genomic-medicine-sweden/nallo/pull/1232) - Changed the re-headering of the SV VCFs, now part of a new subworkflow `REHEADER_SV_VCF`
 - [#1225](https://github.com/genomic-medicine-sweden/nallo/pull/1225) - Replaced `extra_vep_options` with separate `extra_vep_options_snv` and `extra_vep_options_sv` parameters, appended after the core VEP command for each variant type
 - [#1225](https://github.com/genomic-medicine-sweden/nallo/pull/1225) - Moved enrichment VEP flags (`--appris`, `--biotype`, `--hgvs`, etc.) from the hardcoded core command to the default values of `extra_vep_options_snv` and `extra_vep_options_sv`; the core command now contains only pipeline-critical flags
+- [#1244](https://github.com/genomic-medicine-sweden/nallo/pull/1244) - Updated `hiphase` module to fix typo in `hiphase` command
 
 ### Removed
 

--- a/modules.json
+++ b/modules.json
@@ -243,7 +243,7 @@
                     },
                     "hiphase": {
                         "branch": "master",
-                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
+                        "git_sha": "32d9d7b17b837f68b7f3916f53bfa90d1b434fdd",
                         "installed_by": ["modules"]
                     },
                     "longphase/haplotag": {

--- a/modules/nf-core/hiphase/main.nf
+++ b/modules/nf-core/hiphase/main.nf
@@ -66,7 +66,7 @@ process HIPHASE {
         ${snv_args} \\
         ${sv_args} \\
         ${summary_file_arg} \\
-        ${blocks_file_arg} \ \
+        ${blocks_file_arg} \\
         ${stats_file_arg} \\
         ${haplotag_file_arg}
     """

--- a/modules/nf-core/hiphase/tests/main.nf.test.snap
+++ b/modules/nf-core/hiphase/tests/main.nf.test.snap
@@ -63,11 +63,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-03-19T11:28:13.474104448",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-19T11:28:13.474104448"
+        }
     },
     "homo_sapiens - pacbio - [bam, bai, snv_vcf, snv_csi, [], [], []] - fasta - fai - false - tsv": {
         "content": [
@@ -113,7 +113,7 @@
                         {
                             "id": "test"
                         },
-                        "test_snv_phased.vcf.gz:md5,782498d8699a1582d6b1165471905c41"
+                        "test_snv_phased.vcf.gz:md5,dc898f8a5526369e84ea34bbf820ee78"
                     ]
                 ],
                 "vcfs_indexes": [
@@ -133,11 +133,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-08-21T10:18:16.071352599",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-19T11:27:57.734084707"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
     },
     "homo_sapiens - pacbio - [bam, bai, snv_vcf, snv_csi, [], [], []] - fasta - fai - true - tsv": {
         "content": [
@@ -146,7 +146,7 @@
                     {
                         "id": "test"
                     },
-                    "test_snv_phased.vcf.gz:md5,1713cf1f236af3792f5bc35fb102a547"
+                    "test_snv_phased.vcf.gz:md5,abec5b169e3ecf1b345dbbb4de93dd07"
                 ]
             ],
             [
@@ -172,7 +172,7 @@
                     {
                         "id": "test"
                     },
-                    "NA03697B2_downsampled.pbmm2.repeats_haplotagged.bam:md5,9da7936296ad10c9e6c93cb691dff3b0"
+                    "NA03697B2_downsampled.pbmm2.repeats_haplotagged.bam:md5,c18a4030683f2ad7d4889922142bbb03"
                 ]
             ],
             [
@@ -180,7 +180,7 @@
                     {
                         "id": "test"
                     },
-                    "NA03697B2_downsampled.pbmm2.repeats_haplotagged.bam.bai:md5,13756deefcf2a3fc54258c57ea8cca6f"
+                    "NA03697B2_downsampled.pbmm2.repeats_haplotagged.bam.bai:md5,c2545d124e5398d397670758f5e46fc4"
                 ]
             ],
             {
@@ -193,11 +193,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-08-21T10:18:20.011856866",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-19T12:18:46.597240628"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
     },
     "homo_sapiens - pacbio - [bam, bai, snv_vcf, snv_csi, [], [], []] - fasta - fai - true - csv": {
         "content": [
@@ -206,7 +206,7 @@
                     {
                         "id": "test"
                     },
-                    "test_snv_phased.vcf.gz:md5,c92e59f32907e82474e41f7b4ed5e1cc"
+                    "test_snv_phased.vcf.gz:md5,b7c30e9a2b2483847e7d4dcf87a5084c"
                 ]
             ],
             [
@@ -232,7 +232,7 @@
                     {
                         "id": "test"
                     },
-                    "NA03697B2_downsampled.pbmm2.repeats_haplotagged.bam:md5,7bfb117026cfe29a00b8f0278a0615ce"
+                    "NA03697B2_downsampled.pbmm2.repeats_haplotagged.bam:md5,b7ebb05ee7914006481278b54f9e8202"
                 ]
             ],
             [
@@ -240,7 +240,7 @@
                     {
                         "id": "test"
                     },
-                    "NA03697B2_downsampled.pbmm2.repeats_haplotagged.bam.bai:md5,13756deefcf2a3fc54258c57ea8cca6f"
+                    "NA03697B2_downsampled.pbmm2.repeats_haplotagged.bam.bai:md5,c2545d124e5398d397670758f5e46fc4"
                 ]
             ],
             {
@@ -253,11 +253,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-08-21T10:18:24.035944207",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-19T12:18:02.582432335"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
     },
     "homo_sapiens - pacbio - [bam, bai, snv_vcf, snv_csi, [], [], []] - fasta - fai - true - tsv - stub": {
         "content": [
@@ -333,11 +333,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-03-19T11:28:18.607491047",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-19T11:28:18.607491047"
+        }
     },
     "homo_sapiens - pacbio - [bam, bai, snv_vcf, snv_csi, [], [], []] - fasta - fai - true - csv - stub": {
         "content": [
@@ -413,10 +413,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-03-19T11:28:23.623561036",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-19T11:28:23.623561036"
+        }
     }
 }


### PR DESCRIPTION
## Description

This PR closes #1242.
Fixes error because of an invalid escape sequence in `hiphase` with latest version of nextflow (26.08.0-edge).

### Added

-

### Changed

- Updated hiphase module to fix typo in hiphase command

### Fixed

-

### Removed

-
