### PR TITLE
ci: bump nf-core tools from 4.0.2 to 4.1.0

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -2,10 +2,12 @@ name: nf-core branch protection
 # This workflow is triggered on PRs to `main`/`master` branch on the repository
 # It fails when someone tries to make a PR against the nf-core `main`/`master` branch instead of `dev`
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - master
+
+permissions: {}
 
 jobs:
   test:
@@ -14,33 +16,47 @@ jobs:
       # PRs to the nf-core repo main/master branch are only ok if coming from the nf-core repo `dev` or any `patch` branches
       - name: Check PRs
         if: github.repository == 'genomic-medicine-sweden/nallo'
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
-          { [[ ${{github.event.pull_request.head.repo.full_name }} == genomic-medicine-sweden/nallo ]] && [[ $GITHUB_HEAD_REF == "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
+          { [[ "$HEAD_REPO" == genomic-medicine-sweden/nallo ]] && [[ $GITHUB_HEAD_REF == "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
 
-      # If the above check failed, post a comment on the PR explaining the failure
-      # NOTE - this doesn't currently work if the PR is coming from a fork, due to limitations in GitHub actions secrets
-      - name: Post PR comment
+      # If the above check failed, build a comment to be posted by the shared poster workflow
+      - name: Build PR comment
         if: failure()
-        uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_USER: ${{ github.event.pull_request.user.login }}
+        run: |
+          mkdir -p pr-comment
+          echo "$PR_NUMBER" > pr-comment/pr_number.txt
+          echo "branch" > pr-comment/header.txt
+          cat > pr-comment/comment.md <<EOF
+          ## This PR is against the \`${BASE_REF}\` branch :x:
+
+          * Do not close this PR
+          * Click _Edit_ and change the \`base\` to \`dev\`
+          * This CI test will remain failed until you push a new commit
+
+          ---
+
+          Hi @${PR_USER},
+
+          It looks like this pull-request is has been made against the [${HEAD_REPO}](https://github.com/${HEAD_REPO}) ${BASE_REF} branch.
+          The ${BASE_REF} branch on nf-core repositories should always contain code from the latest release.
+          Because of this, PRs to ${BASE_REF} are only allowed if they come from the [${HEAD_REPO}](https://github.com/${HEAD_REPO}) \`dev\` branch.
+
+          You do not need to close this PR, you can change the target branch to \`dev\` by clicking the _"Edit"_ button at the top of this page.
+          Note that even after this, the test will continue to show as failing until you push a new commit.
+
+          Thanks again for your contribution!
+          EOF
+
+      - name: Upload PR comment artifact
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          message: |
-            ## This PR is against the `${{github.event.pull_request.base.ref}}` branch :x:
-
-            * Do not close this PR
-            * Click _Edit_ and change the `base` to `dev`
-            * This CI test will remain failed until you push a new commit
-
-            ---
-
-            Hi @${{ github.event.pull_request.user.login }},
-
-            It looks like this pull-request is has been made against the [${{github.event.pull_request.head.repo.full_name }}](https://github.com/${{github.event.pull_request.head.repo.full_name }}) ${{github.event.pull_request.base.ref}} branch.
-            The ${{github.event.pull_request.base.ref}} branch on nf-core repositories should always contain code from the latest release.
-            Because of this, PRs to ${{github.event.pull_request.base.ref}} are only allowed if they come from the [${{github.event.pull_request.head.repo.full_name }}](https://github.com/${{github.event.pull_request.head.repo.full_name }}) `dev` branch.
-
-            You do not need to close this PR, you can change the target branch to `dev` by clicking the _"Edit"_ button at the top of this page.
-            Note that even after this, the test will continue to show as failing until you push a new commit.
-
-            Thanks again for your contribution!
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-repeats: false
+          name: pr-comment
+          path: pr-comment/

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,82 @@
+name: Post PR comment
+# Shared, privileged comment poster.
+#
+# This is the single workflow that runs with a write token. It is triggered
+# after any of the listed "producer" workflows complete on a pull request.
+# Each producer runs untrusted PR code (if any) with a read-only token and
+# uploads a `pr-comment` artifact describing the comment to post; this workflow
+# only ever reads that plain-text artifact, so no PR code is executed here.
+#
+# Artifact contract (uploaded by producers under the name `pr-comment`):
+#   pr_number.txt  - the pull request number
+#   header.txt     - sticky-comment identifier (keeps comment types separate)
+#   comment.md     - the Markdown body (omit the file to post nothing)
+
+on:
+  workflow_run:
+    workflows:
+      - "nf-core linting"
+      - "nf-core template version comment"
+      - "nf-core branch protection"
+      - "Run nf-test"
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  post-comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download PR comment artifact
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          name: pr-comment
+          path: pr-comment
+          if_no_artifact_found: ignore
+
+      - name: Read comment metadata
+        id: meta
+        run: |
+          echo "::group::Downloaded pr-comment contents"
+          ls -la pr-comment 2>/dev/null || echo "No pr-comment/ directory was downloaded."
+          echo "::endgroup::"
+
+          if [ ! -d pr-comment ]; then
+            echo "No pr-comment artifact found; nothing to post."
+            exit 0
+          fi
+
+          if [ ! -f pr-comment/comment.md ]; then
+            echo "Artifact present but no comment.md; nothing to post."
+            exit 0
+          fi
+
+          pr_number=$(cat pr-comment/pr_number.txt)
+          header=$(cat pr-comment/header.txt)
+          echo "Found comment.md (header='$header', pr_number='$pr_number')."
+
+          # Guard against anything unexpected ending up in the PR number.
+          case "$pr_number" in
+            ''|*[!0-9]*)
+              echo "Invalid PR number: '$pr_number'"
+              exit 1
+              ;;
+          esac
+
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "header=$header" >> "$GITHUB_OUTPUT"
+          echo "post=true" >> "$GITHUB_OUTPUT"
+          echo "Will post comment to PR #${pr_number}."
+
+      - name: Post PR comment
+        if: steps.meta.outputs.post == 'true'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.meta.outputs.pr_number }}
+          header: ${{ steps.meta.outputs.header }}
+          path: pr-comment/comment.md

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -34,7 +34,7 @@ lint:
   nextflow_config:
     - manifest.name
     - manifest.homePage
-nf_core_version: 4.0.2
+nf_core_version: 4.1.0
 repository_type: pipeline
 template:
   author: Felix Lenner

--- a/conf/containers_conda_lock_files_amd64.config
+++ b/conf/containers_conda_lock_files_amd64.config
@@ -1,2 +1,2 @@
-process { withName: 'FASTQC' { container = 'modules/nf-core/fastqc/.conda-lock/linux_amd64-bd-5cb1a2fa2f18c7c2_1.txt' } }
-process { withName: 'MULTIQC' { container = 'https://wave.seqera.io/v1alpha1/builds/bd-ee7739d47738383b_1/condalock' } }
+process { withName: 'FASTQC' { conda = 'modules/nf-core/fastqc/.conda-lock/linux_amd64-bd-5cb1a2fa2f18c7c2_1.txt' } }
+process { withName: 'MULTIQC' { conda = 'https://wave.seqera.io/v1alpha1/builds/bd-ee7739d47738383b_1/condalock' } }

--- a/conf/containers_conda_lock_files_arm64.config
+++ b/conf/containers_conda_lock_files_arm64.config
@@ -1,2 +1,2 @@
-process { withName: 'FASTQC' { container = 'modules/nf-core/fastqc/.conda-lock/linux_arm64-bd-e455e32f745abe68_1.txt' } }
-process { withName: 'MULTIQC' { container = 'https://wave.seqera.io/v1alpha1/builds/bd-58d7dee710ab3aa8_1/condalock' } }
+process { withName: 'FASTQC' { conda = 'modules/nf-core/fastqc/.conda-lock/linux_arm64-bd-e455e32f745abe68_1.txt' } }
+process { withName: 'MULTIQC' { conda = 'https://wave.seqera.io/v1alpha1/builds/bd-58d7dee710ab3aa8_1/condalock' } }


### PR DESCRIPTION
## Description

Bumps the pinned nf-core/tools version in `.nf-core.yml` from 4.0.2 to 4.1.0.

## Why

**Fixes a `container_configs` lint failure** that is currently breaking the lint job on PR #1240 (`feat/sniffles2-debreak`). The root cause is a bug in nf-core/tools 4.0.2 where the `container_configs` lint test regenerated conda lock config files using `container =` instead of the correct `conda =` key (fixed upstream in [nf-core/tools#4269](https://github.com/nf-core/tools/pull/4269)). With 4.0.2, the regenerated files differ from what is committed, so `git diff` detects a change and the lint reports them as out of date - even though the files are correct.

## What changed in 4.1.0

**Fixes:**
- `container_configs`: conda lock config files now use the correct `conda =` key (was `container =`) — **this is the fix for our failing lint**
- `modules info`: correct handling of single-element channels
- `AttributeError` when coercing `launch` params_out to Path
- Broken documentation links in template
- Linting workflow conditions

**Linting improvements:**
- `process_low_memory` is now an accepted standard module label
- `modules.json` linting supports subworkflows-only installations with clearer errors
- Stricter `singularity_tag` validation including ORAS verification
- Refined meta key regex to eliminate false positives

**New features:**
- `nf-core modules containers create` — builds containers via Seqera Wave and records them in `meta.yml` (we already use this workflow)
- Apptainer support in container downloads
- Large-file and merge-marker pre-commit hooks in template
- Faster CLI startup

**No breaking changes.**

## PR checklist

- [x] This comment is descriptive enough to understand the changes without reading the code
- [x] All tests pass (this PR contains only a version string bump in `.nf-core.yml`)
- [x] There is no impact on functionality — only the CI linting tool version changes