### PR TITLE
refactor: optimise SVTYPE regex in vep_prep_sv

### DIFF
--- a/modules/local/vep_prep_sv/resources/usr/bin/vep_prep_sv.py
+++ b/modules/local/vep_prep_sv/resources/usr/bin/vep_prep_sv.py
@@ -24,18 +24,19 @@ SVTYPE_REMAP = {
     'INV/INVDUP': 'DUP',  # defensive
 }
 
+_SVTYPE_RE = re.compile(r'SVTYPE=([^;]+)')
+
 
 def remap_svtype(info):
-    m = re.search(r'SVTYPE=([^;]+)', info)
+    m = _SVTYPE_RE.search(info)
     if not m:
         return info
     svtype = m.group(1)
     canonical = SVTYPE_REMAP.get(svtype)
     if canonical is None:
         return info
-    info = re.sub(r'SVTYPE=[^;]+', f'SVTYPE={canonical}', info)
-    info = info + f';ORIG_SVTYPE={svtype}'
-    return info
+    info = _SVTYPE_RE.sub(f'SVTYPE={canonical}', info, count=1)
+    return info + f';ORIG_SVTYPE={svtype}'
 
 
 def main():

--- a/modules/local/vep_prep_sv/resources/usr/bin/vep_prep_sv.py
+++ b/modules/local/vep_prep_sv/resources/usr/bin/vep_prep_sv.py
@@ -28,6 +28,7 @@ _SVTYPE_RE = re.compile(r'SVTYPE=([^;]+)')
 
 
 def remap_svtype(info):
+    """Remap non-canonical SVTYPE in an INFO field string (tab-delimited VCF column 8)."""
     m = _SVTYPE_RE.search(info)
     if not m:
         return info
@@ -35,8 +36,7 @@ def remap_svtype(info):
     canonical = SVTYPE_REMAP.get(svtype)
     if canonical is None:
         return info
-    info = _SVTYPE_RE.sub(f'SVTYPE={canonical}', info, count=1)
-    return info + f';ORIG_SVTYPE={svtype}'
+    return info[: m.start()] + f'SVTYPE={canonical}' + info[m.end() :] + f';ORIG_SVTYPE={svtype}'
 
 
 def main():


### PR DESCRIPTION
Addresses two suggestions from the #1240 review:

- Compile the SVTYPE regex once at module level (`_SVTYPE_RE`) instead of recompiling it on every call to `remap_svtype`
- Reuse the match object's start/end positions to splice the replacement string, avoiding a second regex search

Behaviour is identical; no snapshot changes needed.